### PR TITLE
[TNT-102] feat: 트레이너 초대 코드 표시 및 재발급 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,6 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -169,7 +168,9 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // MockWebServer
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ sonar {
         property "sonar.organization", "yapp-github"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java"
+        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, " +
+                "**/*Exception.java"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }

--- a/src/main/java/com/tnt/application/trainer/TrainerService.java
+++ b/src/main/java/com/tnt/application/trainer/TrainerService.java
@@ -34,7 +34,7 @@ public class TrainerService {
 	}
 
 	public Trainer getTrainer(String memberId) {
-		return trainerRepository.findByMemberIdAndDeletedAtIsNotNull(Long.valueOf(memberId))
+		return trainerRepository.findByMemberIdAndDeletedAtIsNull(Long.valueOf(memberId))
 			.orElseThrow(() -> new NotFoundException(TRAINER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/tnt/application/trainer/TrainerService.java
+++ b/src/main/java/com/tnt/application/trainer/TrainerService.java
@@ -1,0 +1,40 @@
+package com.tnt.application.trainer;
+
+import static com.tnt.global.error.model.ErrorMessage.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tnt.domain.trainer.Trainer;
+import com.tnt.dto.trainer.response.InvitationCodeResponse;
+import com.tnt.global.error.exception.NotFoundException;
+import com.tnt.infrastructure.mysql.repository.trainer.TrainerRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TrainerService {
+
+	private final TrainerRepository trainerRepository;
+
+	public InvitationCodeResponse getInvitationCode(String memberId) {
+		Trainer trainer = getTrainer(memberId);
+
+		return new InvitationCodeResponse(String.valueOf(trainer.getId()), trainer.getInvitationCode());
+	}
+
+	@Transactional
+	public InvitationCodeResponse reissueInvitationCode(String memberId) {
+		Trainer trainer = getTrainer(memberId);
+		trainer.setNewInvitationCode();
+
+		return new InvitationCodeResponse(String.valueOf(trainer.getId()), trainer.getInvitationCode());
+	}
+
+	public Trainer getTrainer(String memberId) {
+		return trainerRepository.findByMemberIdAndDeletedAtIsNotNull(Long.valueOf(memberId))
+			.orElseThrow(() -> new NotFoundException(TRAINER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/tnt/domain/pt/PtTrainerTrainee.java
+++ b/src/main/java/com/tnt/domain/pt/PtTrainerTrainee.java
@@ -1,0 +1,45 @@
+package com.tnt.domain.pt;
+
+import java.time.LocalDate;
+
+import com.tnt.global.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "pt_trainer_trainee")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PtTrainerTrainee extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false, unique = true)
+	private Long id;
+
+	@Column(name = "trainer_id", nullable = false)
+	private Long trainerId;
+
+	@Column(name = "trainee_id", nullable = false)
+	private Long traineeId;
+
+	@Column(name = "started_at", nullable = false)
+	private LocalDate startedAt;
+
+	@Column(name = "finished_pt_count", nullable = false)
+	private int finishedPtCount;
+
+	@Column(name = "total_pt_count", nullable = false)
+	private int totalPtCount;
+
+	@Column(name = "deleted_at")
+	private LocalDate deletedAt;
+}

--- a/src/main/java/com/tnt/domain/trainer/Trainer.java
+++ b/src/main/java/com/tnt/domain/trainer/Trainer.java
@@ -1,0 +1,61 @@
+package com.tnt.domain.trainer;
+
+import static com.tnt.global.error.model.ErrorMessage.*;
+import static io.micrometer.common.util.StringUtils.*;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import com.tnt.global.common.entity.BaseTimeEntity;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "trainer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Trainer extends BaseTimeEntity {
+
+	private static final int INVITATION_CODE_LENGTH = 8;
+
+	@Id
+	@Tsid
+	@Column(name = "id", nullable = false, unique = true)
+	private Long id;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "invitation_code", nullable = false, length = INVITATION_CODE_LENGTH)
+	private String invitationCode;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public Trainer(Long id, Long memberId, String invitationCode) {
+		this.id = Objects.requireNonNull(id, TRAINER_NULL_ID.getMessage());
+		this.memberId = Objects.requireNonNull(memberId, TRAINER_NULL_MEMBER_ID.getMessage());
+		this.invitationCode = validateInvitationCode(invitationCode);
+	}
+
+	public void setNewInvitationCode() {
+		// TODO: Implement reissueInvitationCode
+	}
+
+	private String validateInvitationCode(String invitationCode) {
+		if (isBlank(invitationCode) || invitationCode.length() != INVITATION_CODE_LENGTH) {
+			throw new IllegalArgumentException(TRAINER_INVALID_INVITATION_CODE.getMessage());
+		}
+
+		return invitationCode;
+	}
+}

--- a/src/main/java/com/tnt/domain/trainer/Trainer.java
+++ b/src/main/java/com/tnt/domain/trainer/Trainer.java
@@ -53,11 +53,11 @@ public class Trainer extends BaseTimeEntity {
 	}
 
 	public void setNewInvitationCode() {
+		byte[] hashBytes;
 		StringBuilder sb = new StringBuilder();
 
 		String uuidString = UUID.randomUUID().toString();
 		byte[] uuidStringBytes = uuidString.getBytes(StandardCharsets.UTF_8);
-		byte[] hashBytes;
 
 		try {
 			MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/com/tnt/domain/trainer/Trainer.java
+++ b/src/main/java/com/tnt/domain/trainer/Trainer.java
@@ -3,10 +3,15 @@ package com.tnt.domain.trainer;
 import static com.tnt.global.error.model.ErrorMessage.*;
 import static io.micrometer.common.util.StringUtils.*;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 import com.tnt.global.common.entity.BaseTimeEntity;
+import com.tnt.global.error.exception.TnTException;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.Column;
@@ -24,7 +29,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Trainer extends BaseTimeEntity {
 
-	private static final int INVITATION_CODE_LENGTH = 8;
+	public static final int INVITATION_CODE_LENGTH = 8;
 
 	@Id
 	@Tsid
@@ -41,14 +46,31 @@ public class Trainer extends BaseTimeEntity {
 	private LocalDateTime deletedAt;
 
 	@Builder
-	public Trainer(Long id, Long memberId, String invitationCode) {
-		this.id = Objects.requireNonNull(id, TRAINER_NULL_ID.getMessage());
+	public Trainer(Long id, Long memberId) {
+		this.id = id;
 		this.memberId = Objects.requireNonNull(memberId, TRAINER_NULL_MEMBER_ID.getMessage());
-		this.invitationCode = validateInvitationCode(invitationCode);
+		setNewInvitationCode();
 	}
 
 	public void setNewInvitationCode() {
-		// TODO: Implement reissueInvitationCode
+		StringBuilder sb = new StringBuilder();
+
+		String uuidString = UUID.randomUUID().toString();
+		byte[] uuidStringBytes = uuidString.getBytes(StandardCharsets.UTF_8);
+		byte[] hashBytes;
+
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+			hashBytes = messageDigest.digest(uuidStringBytes);
+		} catch (NoSuchAlgorithmException e) {
+			throw new TnTException(TRAINER_INVITATION_CODE_GENERATE_FAILED, e);
+		}
+
+		for (int j = 0; j < 4; j++) {
+			sb.append(String.format("%02x", hashBytes[j]));
+		}
+
+		this.invitationCode = validateInvitationCode(sb.toString().toUpperCase());
 	}
 
 	private String validateInvitationCode(String invitationCode) {

--- a/src/main/java/com/tnt/dto/trainer/response/InvitationCodeResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/InvitationCodeResponse.java
@@ -8,7 +8,7 @@ public record InvitationCodeResponse(
 	@Schema(description = "트레이너 id", example = "23984725", type = "string")
 	String trainerId,
 
-	@Schema(description = "트레이너의 초대 코드", example = "3h38g9h3", type = "string")
+	@Schema(description = "트레이너의 초대 코드", example = "2H9DG4X3", type = "string")
 	String invitationCode
 ) {
 

--- a/src/main/java/com/tnt/dto/trainer/response/InvitationCodeResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/InvitationCodeResponse.java
@@ -1,0 +1,15 @@
+package com.tnt.dto.trainer.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트레이너의 초대 코드 응답")
+public record InvitationCodeResponse(
+
+	@Schema(description = "트레이너 id", example = "23984725", type = "string")
+	String trainerId,
+
+	@Schema(description = "트레이너의 초대 코드", example = "3h38g9h3", type = "string")
+	String invitationCode
+) {
+
+}

--- a/src/main/java/com/tnt/global/auth/annotation/AuthMember.java
+++ b/src/main/java/com/tnt/global/auth/annotation/AuthMember.java
@@ -1,0 +1,18 @@
+package com.tnt.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : username")
+public @interface AuthMember {
+
+}

--- a/src/main/java/com/tnt/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/tnt/global/error/exception/NotFoundException.java
@@ -7,4 +7,8 @@ public class NotFoundException extends TnTException {
 	public NotFoundException(ErrorMessage errorMessage) {
 		super(errorMessage);
 	}
+
+	public NotFoundException(ErrorMessage errorMessage, Throwable cause) {
+		super(errorMessage, cause);
+	}
 }

--- a/src/main/java/com/tnt/global/error/exception/OAuthException.java
+++ b/src/main/java/com/tnt/global/error/exception/OAuthException.java
@@ -7,4 +7,8 @@ public class OAuthException extends TnTException {
 	public OAuthException(ErrorMessage errorMessage) {
 		super(errorMessage);
 	}
+
+	public OAuthException(ErrorMessage errorMessage, Throwable cause) {
+		super(errorMessage, cause);
+	}
 }

--- a/src/main/java/com/tnt/global/error/exception/TnTException.java
+++ b/src/main/java/com/tnt/global/error/exception/TnTException.java
@@ -7,4 +7,8 @@ public class TnTException extends RuntimeException {
 	public TnTException(ErrorMessage errorMessage) {
 		super(errorMessage.getMessage());
 	}
+
+	public TnTException(ErrorMessage errorMessage, Throwable cause) {
+		super(errorMessage.getMessage(), cause);
+	}
 }

--- a/src/main/java/com/tnt/global/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/tnt/global/error/exception/UnauthorizedException.java
@@ -7,4 +7,8 @@ public class UnauthorizedException extends TnTException {
 	public UnauthorizedException(ErrorMessage errorMessage) {
 		super(errorMessage);
 	}
+
+	public UnauthorizedException(ErrorMessage errorMessage, Throwable cause) {
+		super(errorMessage, cause);
+	}
 }

--- a/src/main/java/com/tnt/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tnt/global/error/handler/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.tnt.global.error.handler;
 
 import static com.tnt.global.error.model.ErrorMessage.*;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
 
 import java.security.SecureRandom;
 import java.time.DateTimeException;
@@ -111,6 +108,14 @@ public class GlobalExceptionHandler {
 		return new ErrorResponse(exception.getMessage());
 	}
 
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(IllegalArgumentException.class)
+	protected ErrorResponse handleIllegalArgumentException(IllegalArgumentException exception) {
+		log.error(exception.getMessage(), exception);
+
+		return new ErrorResponse(exception.getMessage());
+	}
+
 	// 기타 500 예외
 	@ResponseStatus(INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(RuntimeException.class)
@@ -124,7 +129,7 @@ public class GlobalExceptionHandler {
 		String errorKeyInfo = String.format(ERROR_KEY_FORMAT, sb);
 		String exceptionTypeInfo = String.format(EXCEPTION_CLASS_TYPE_MESSAGE_FORMANT, exception.getClass());
 
-		log.error("{}{}{}", exception.getMessage(), errorKeyInfo, exceptionTypeInfo, exception);
+		log.error("{} {} {}", exception.getMessage(), errorKeyInfo, exceptionTypeInfo, exception);
 
 		return new ErrorResponse(SERVER_ERROR + errorKeyInfo);
 	}

--- a/src/main/java/com/tnt/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/tnt/global/error/model/ErrorMessage.java
@@ -30,7 +30,12 @@ public enum ErrorMessage {
 	MATCHING_KEY_NOT_FOUND("매칭키 찾기에 실패했습니다."),
 	FAILED_TO_VERIFY_ID_TOKEN("Apple ID 토큰 검증에 실패했습니다."),
 
-	MEMBER_NOT_FOUND("존재하지 않는 회원입니다.");
+	MEMBER_NOT_FOUND("존재하지 않는 회원입니다."),
+
+	TRAINER_NULL_ID("트레이너 id가 null 입니다."),
+	TRAINER_NULL_MEMBER_ID("트레이너 member id가 null 입니다."),
+	TRAINER_INVALID_INVITATION_CODE("초대 코드가 올바르지 않습니다."),
+	TRAINER_NOT_FOUND("존재하지 않는 트레이너입니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/tnt/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/tnt/global/error/model/ErrorMessage.java
@@ -35,7 +35,8 @@ public enum ErrorMessage {
 	TRAINER_NULL_ID("트레이너 id가 null 입니다."),
 	TRAINER_NULL_MEMBER_ID("트레이너 member id가 null 입니다."),
 	TRAINER_INVALID_INVITATION_CODE("초대 코드가 올바르지 않습니다."),
-	TRAINER_NOT_FOUND("존재하지 않는 트레이너입니다.");
+	TRAINER_NOT_FOUND("존재하지 않는 트레이너입니다."),
+	TRAINER_INVITATION_CODE_GENERATE_FAILED("트레이너 초대 코드 생성에 실패했습니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
@@ -1,0 +1,12 @@
+package com.tnt.infrastructure.mysql.repository.trainer;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tnt.domain.trainer.Trainer;
+
+public interface TrainerRepository extends JpaRepository<Trainer, Long> {
+
+	Optional<Trainer> findByMemberIdAndDeletedAtIsNotNull(Long memberId);
+}

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
@@ -8,5 +8,5 @@ import com.tnt.domain.trainer.Trainer;
 
 public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 
-	Optional<Trainer> findByMemberIdAndDeletedAtIsNotNull(Long memberId);
+	Optional<Trainer> findByMemberIdAndDeletedAtIsNull(Long memberId);
 }

--- a/src/main/java/com/tnt/presentation/trainer/TrainerController.java
+++ b/src/main/java/com/tnt/presentation/trainer/TrainerController.java
@@ -1,0 +1,40 @@
+package com.tnt.presentation.trainer;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tnt.application.trainer.TrainerService;
+import com.tnt.dto.trainer.response.InvitationCodeResponse;
+import com.tnt.global.auth.annotation.AuthMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "트레이너", description = "트레이너 관련 API")
+@RestController
+@RequestMapping("/trainers")
+@RequiredArgsConstructor
+public class TrainerController {
+
+	private final TrainerService trainerService;
+
+	@Operation(summary = "트레이너 초대 코드 불러오기 API")
+	@ResponseStatus(OK)
+	@GetMapping("/invitation-code")
+	public InvitationCodeResponse getInvitationCode(@AuthMember String memberId) {
+		return trainerService.getInvitationCode(memberId);
+	}
+
+	@Operation(summary = "트레이너 초대 코드 재발급 API")
+	@ResponseStatus(CREATED)
+	@PutMapping("/invitation-code")
+	public InvitationCodeResponse reissueInvitationCode(@AuthMember String memberId) {
+		return trainerService.reissueInvitationCode(memberId);
+	}
+}

--- a/src/main/resources/log4j2-dev.yml
+++ b/src/main/resources/log4j2-dev.yml
@@ -39,9 +39,19 @@ Configuration:
       AppenderRef:
         ref: RollingFile_Appender
     Logger:
-      name: com.tnt
-      additivity: false
-      level: DEBUG
-      includeLocation: false
-      AppenderRef:
-        ref: RollingFile_Appender
+      - name: com.tnt
+        additivity: false
+        level: DEBUG
+        includeLocation: false
+        AppenderRef:
+          ref: RollingFile_Appender
+      - name: org.hibernate.SQL
+        level: DEBUG
+        additivity: false
+        AppenderRef:
+          ref: RollingFile_Appender
+      - name: org.hibernate.orm.jdbc.bind
+        level: TRACE
+        additivity: false
+        AppenderRef:
+          ref: RollingFile_Appender

--- a/src/main/resources/log4j2-local.yml
+++ b/src/main/resources/log4j2-local.yml
@@ -24,8 +24,18 @@ Configuration:
       AppenderRef:
         ref: Console_Appender
     Logger:
-      name: com.tnt
-      additivity: false
-      level: DEBUG
-      AppenderRef:
-        ref: Console_Appender
+      - name: com.tnt
+        additivity: false
+        level: DEBUG
+        AppenderRef:
+          ref: Console_Appender
+      - name: org.hibernate.SQL
+        level: DEBUG
+        additivity: false
+        AppenderRef:
+          ref: Console_Appender
+      - name: org.hibernate.orm.jdbc.bind
+        level: TRACE
+        additivity: false
+        AppenderRef:
+          ref: Console_Appender

--- a/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
+++ b/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
@@ -1,0 +1,65 @@
+package com.tnt.application.trainer;
+
+import static com.tnt.domain.trainer.Trainer.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.tnt.domain.trainer.Trainer;
+import com.tnt.dto.trainer.response.InvitationCodeResponse;
+import com.tnt.global.error.exception.NotFoundException;
+import com.tnt.infrastructure.mysql.repository.trainer.TrainerRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TrainerServiceTest {
+
+	@InjectMocks
+	private TrainerService trainerService;
+
+	@Mock
+	private TrainerRepository trainerRepository;
+
+	@Test
+	@DisplayName("트레이너 초대 코드 불러오기 성공")
+	void get_invitation_code_success() {
+		// given
+		Long trainerId = 1L;
+		Long memberId = 1L;
+
+		Trainer trainer = Trainer.builder()
+			.id(trainerId)
+			.memberId(memberId)
+			.build();
+
+		given(trainerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(
+			java.util.Optional.of(trainer));
+
+		// when
+		InvitationCodeResponse response = trainerService.getInvitationCode(String.valueOf(memberId));
+
+		// then
+		assertThat(response.trainerId()).isEqualTo(String.valueOf(trainerId));
+		assertThat(response.invitationCode()).isNotNull();
+		assertThat(response.invitationCode()).hasSize(INVITATION_CODE_LENGTH);
+	}
+
+	@Test
+	@DisplayName("트레이너 초대 코드 불러오기 실패 - 존재하지 않는 계정")
+	void get_invitation_code_no_member_fail() {
+		// given
+		Long memberId = 99L;
+		String memberIdString = String.valueOf(memberId);
+
+		given(trainerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(java.util.Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> trainerService.getInvitationCode(memberIdString)).isInstanceOf(
+			NotFoundException.class);
+	}
+}

--- a/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
+++ b/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
@@ -62,4 +62,31 @@ class TrainerServiceTest {
 		assertThatThrownBy(() -> trainerService.getInvitationCode(memberIdString)).isInstanceOf(
 			NotFoundException.class);
 	}
+
+	@Test
+	@DisplayName("트레이너 초대 코드 재발급 성공")
+	void reissue_invitation_code_success() {
+		// given
+		Long trainerId = 1L;
+		Long memberId = 123L;
+
+		Trainer trainer = Trainer.builder()
+			.id(trainerId)
+			.memberId(memberId)
+			.build();
+
+		String invitationCodeBefore = trainer.getInvitationCode();
+
+		given(trainerRepository.findByMemberIdAndDeletedAtIsNull(memberId)).willReturn(
+			java.util.Optional.of(trainer));
+
+		// when
+		InvitationCodeResponse response = trainerService.reissueInvitationCode(String.valueOf(memberId));
+
+		// then
+		assertThat(response.trainerId()).isEqualTo(String.valueOf(trainerId));
+		assertThat(response.invitationCode()).isNotNull();
+		assertThat(response.invitationCode()).hasSize(INVITATION_CODE_LENGTH);
+		assertThat(response.invitationCode()).isNotEqualTo(invitationCodeBefore);
+	}
 }

--- a/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
@@ -1,0 +1,79 @@
+package com.tnt.presentation.trainer;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tnt.domain.trainer.Trainer;
+import com.tnt.infrastructure.mysql.repository.trainer.TrainerRepository;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class TrainerControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private TrainerRepository trainerRepository;
+
+	@Test
+	@DisplayName("통합 테스트 - 트레이너 초대 코드 불러오기 성공")
+	@WithMockUser(username = "1")
+	void get_invitation_code_success() throws Exception {
+		// given
+		Long memberId = 1L;
+
+		Trainer trainer = Trainer.builder()
+			.memberId(memberId)
+			.build();
+
+		trainerRepository.save(trainer);
+
+		// when & then
+		mockMvc.perform(get("/trainers/invitation-code")).andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 트레이너 초대 코드 불러오기 실패 - 존재하지 않는 계정")
+	@WithMockUser(username = "2")
+	void get_invitation_code_fail() throws Exception {
+		// given
+		Long memberId = 1L;
+
+		Trainer trainer = Trainer.builder()
+			.memberId(memberId)
+			.build();
+
+		trainerRepository.save(trainer);
+
+		// when & then
+		mockMvc.perform(get("/trainers/invitation-code")).andExpect(status().is4xxClientError());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 트레이너 초대 코드 재발급 성공")
+	@WithMockUser(username = "3")
+	void reissue_invitation_code_success() throws Exception {
+		// given
+		Long memberId = 3L;
+
+		Trainer trainer = Trainer.builder()
+			.memberId(memberId)
+			.build();
+
+		trainerRepository.save(trainer);
+
+		// when & then
+		mockMvc.perform(put("/trainers/invitation-code")).andExpect(status().isCreated());
+	}
+}


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #15 

**✅ Tasks**

- 트레이너가 자신의 초대 코드를 볼 수 있는 API 구현
- 트레이너가 자신의 초대 코드를 재발급 받을 수 있는 API 구현

**🙋🏻 More**

- Service는 단위 테스트, Controller는 `MockMvc`를 이용한 통합 테스트를 진행하도록 했습니다.
- 통합 테스트를 진행하기 위해서 Filter를 생략하고 `@WithMockUser`로 쉽게 요청을 할 수 있도록 설정했습니다.
- Custom Exception은 catch 후 다시 `throw`시 스택을 그대로 가져갈 수 있도록 각 생성자를 추가했습니다.
