### PR TITLE
[TNT-107] feat: FCM 관련 세팅 및 어댑터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ sonar {
         property "sonar.organization", "yapp-github"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, **/*Exception.java", "**/*Adapter.java"
+        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, " +
+                "**/*Exception.java, **/*Adapter.java"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ sonar {
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, " +
-                "**/*Exception.java"
+                "**/*Exception.java", "**/*Adapter.java"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }
@@ -84,7 +84,8 @@ jacocoTestReport {
                     fileTree(dir: it, excludes: [
                             "**/*Application*",
                             "**/*Config*",
-                            "**/*DynamicQuery*"
+                            "**/*DynamicQuery*",
+                            "**/*error*"
                     ] + Qdomains)
                 })
         )
@@ -118,7 +119,8 @@ jacocoTestCoverageVerification {
                     '*.dto.*',
                     '*.*AppleEcdsaKeyProvider',
                     '*.Q*',
-                    '*.DynamicQuery'
+                    '*.DynamicQuery',
+                    '*.*Adapter'
             ]
         }
     }
@@ -182,4 +184,7 @@ dependencies {
     annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
+    // Firebase
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,7 @@ sonar {
         property "sonar.organization", "yapp-github"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, " +
-                "**/*Exception.java", "**/*Adapter.java"
+        property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, **/*Exception.java", "**/*Adapter.java"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }

--- a/src/main/java/com/tnt/application/member/OAuthService.java
+++ b/src/main/java/com/tnt/application/member/OAuthService.java
@@ -84,6 +84,9 @@ public class OAuthService {
 			return new OAuthLoginResponse(null, socialId, false);
 		}
 
+		findMember.updateFcmTokenIfExpired(request.fcmToken());
+		memberRepository.save(findMember);
+
 		String sessionId = String.valueOf(TSID.Factory.getTsid());
 
 		sessionService.createOrUpdateSession(sessionId, String.valueOf(findMember.getId()));

--- a/src/main/java/com/tnt/domain/member/Member.java
+++ b/src/main/java/com/tnt/domain/member/Member.java
@@ -31,6 +31,9 @@ public class Member extends BaseTimeEntity {
 	@Column(name = "social_id", nullable = false, unique = true, length = 50)
 	private String socialId;
 
+	@Column(name = "fcm_token", nullable = false, length = 255)
+	private String fcmToken;
+
 	@Column(name = "email", nullable = false, length = 100)
 	private String email;
 
@@ -63,11 +66,12 @@ public class Member extends BaseTimeEntity {
 	private SocialType socialType;
 
 	@Builder
-	public Member(Long id, String socialId, String email, String name, LocalDate birthday, String profileImageUrl,
-		boolean serviceAgreement, boolean collectionAgreement, boolean advertisementAgreement, boolean pushAgreement,
-		SocialType socialType) {
+	public Member(Long id, String socialId, String fcmToken, String email, String name, LocalDate birthday,
+		String profileImageUrl, boolean serviceAgreement, boolean collectionAgreement, boolean advertisementAgreement,
+		boolean pushAgreement, SocialType socialType) {
 		this.id = id;
 		this.socialId = socialId;
+		this.fcmToken = fcmToken;
 		this.email = email;
 		this.name = name;
 		this.birthday = birthday;
@@ -77,5 +81,11 @@ public class Member extends BaseTimeEntity {
 		this.advertisementAgreement = advertisementAgreement;
 		this.pushAgreement = pushAgreement;
 		this.socialType = socialType;
+	}
+
+	public void updateFcmTokenIfExpired(String fcmToken) {
+		if (!this.fcmToken.equals(fcmToken)) {
+			this.fcmToken = fcmToken;
+		}
 	}
 }

--- a/src/main/java/com/tnt/dto/member/request/OAuthLoginRequest.java
+++ b/src/main/java/com/tnt/dto/member/request/OAuthLoginRequest.java
@@ -9,6 +9,10 @@ public record OAuthLoginRequest(
 	@NotBlank(message = "소셜 로그인 타입은 필수입니다.")
 	String socialType,
 
+	@Schema(description = "FCM 토큰", example = "dsl5f7iho-28yg2g290u2fj0-23348-23r05")
+	@NotBlank(message = "FCM 토큰은 필수입니다.")
+	String fcmToken,
+
 	@Schema(description = "소셜 액세스 토큰 (카카오 로그인 시)", example = "atweroiuhoresihsgfkn", type = "string")
 	String socialAccessToken,
 

--- a/src/main/java/com/tnt/global/config/FcmConfig.java
+++ b/src/main/java/com/tnt/global/config/FcmConfig.java
@@ -1,0 +1,32 @@
+package com.tnt.global.config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+@Configuration
+@Profile({"prod", "dev"})
+public class FcmConfig {
+
+	@Value("${firebase.config.path}")
+	private String firebaseConfigPath;
+
+	@Bean
+	public FirebaseApp firebaseApp() throws IOException {
+		FileInputStream serviceAccount = new FileInputStream(firebaseConfigPath);
+
+		FirebaseOptions options = FirebaseOptions.builder()
+			.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+			.build();
+
+		return FirebaseApp.initializeApp(options);
+	}
+}

--- a/src/main/java/com/tnt/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/tnt/global/error/model/ErrorMessage.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorMessage {
 
 	SERVER_ERROR("서버 에러가 발생했습니다."),
+	FCM_FAILED("FCM 전송에 실패했습니다."),
 
 	CLIENT_BAD_REQUEST("잘못된 요청입니다."),
 	FAILED_TO_PROCESS_REQUEST("요청 진행에 실패했습니다."),

--- a/src/main/java/com/tnt/infrastructure/fcm/FcmAdapter.java
+++ b/src/main/java/com/tnt/infrastructure/fcm/FcmAdapter.java
@@ -1,0 +1,31 @@
+package com.tnt.infrastructure.fcm;
+
+import static com.tnt.global.error.model.ErrorMessage.*;
+
+import org.springframework.stereotype.Component;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.tnt.global.error.exception.TnTException;
+
+@Component
+public class FcmAdapter {
+
+	public void sendNotificationByToken(String token, String title, String body, String clickActionUrl) {
+		Message message = Message.builder()
+			.setToken(token)
+			.setNotification(com.google.firebase.messaging.Notification.builder()
+				.setTitle(title)
+				.setBody(body)
+				.build())
+			.putData("click_action", clickActionUrl)
+			.build();
+
+		try {
+			FirebaseMessaging.getInstance().send(message);
+		} catch (FirebaseMessagingException e) {
+			throw new TnTException(FCM_FAILED, e);
+		}
+	}
+}

--- a/src/test/java/com/tnt/application/member/OAuthServiceTest.java
+++ b/src/test/java/com/tnt/application/member/OAuthServiceTest.java
@@ -1,10 +1,7 @@
 package com.tnt.application.member;
 
-import static com.tnt.global.error.model.ErrorMessage.APPLE_AUTH_ERROR;
-import static com.tnt.global.error.model.ErrorMessage.FAILED_TO_FETCH_USER_INFO;
-import static com.tnt.global.error.model.ErrorMessage.UNSUPPORTED_SOCIAL_TYPE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.tnt.global.error.model.ErrorMessage.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.io.IOException;
@@ -82,7 +79,7 @@ class OAuthServiceTest {
 	@DisplayName("존재하지 않는 회원 신규 회원으로 간주하고 리턴")
 	void member_not_found() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "kakao-access-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "kakao-access-token", null, null);
 
 		mockWebServer.enqueue(new MockResponse()
 			.setResponseCode(200)  // 성공 응답으로 설정
@@ -105,7 +102,7 @@ class OAuthServiceTest {
 	@DisplayName("지원하지 않는 소셜 타입 예외 발생")
 	void unsupported_social_type_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("NAVER", "some-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest("NAVER", "fcm", "some-token", null, null);
 
 		// when & then
 		assertThatThrownBy(() -> oAuthService.oauthLogin(request))
@@ -117,7 +114,7 @@ class OAuthServiceTest {
 	@DisplayName("Kakao 로그인 실패 시 예외 발생")
 	void kakao_login_failure_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "invalid-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "invalid-token", null, null);
 
 		String errorResponse = "{\"msg\": \"this access token does not exist\", \"code\": -401}";
 
@@ -136,7 +133,7 @@ class OAuthServiceTest {
 	@DisplayName("Apple 클라이언트 인증 실패")
 	void apple_client_authentication_failure_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, "invalid-auth-code", null);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, "invalid-auth-code", null);
 
 		mockWebServer.enqueue(new MockResponse()
 			.setResponseCode(400)
@@ -153,7 +150,7 @@ class OAuthServiceTest {
 	@DisplayName("Apple 로그인 실패 - Android")
 	void apple_token_verification_failure_error_android() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "asdf", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", "asdf", null, null);
 
 		mockWebServer.enqueue(new MockResponse().setResponseCode(401));
 
@@ -167,7 +164,7 @@ class OAuthServiceTest {
 	@DisplayName("Apple 로그인 실패 - iOS")
 	void apple_token_verification_failure_error_ios() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, "asdf", null);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, "asdf", null);
 
 		mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
@@ -181,7 +178,7 @@ class OAuthServiceTest {
 	@DisplayName("Kakao 로그인 성공")
 	void kakao_login_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "valid-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "valid-token", null, null);
 		Member member = mock(Member.class);
 		given(member.getId()).willReturn(1L);
 
@@ -220,7 +217,7 @@ class OAuthServiceTest {
 			.withIssuedAt(new Date())
 			.sign(Algorithm.RSA256(publicKey, privateKey));
 
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, null, mockIdToken);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, null, mockIdToken);
 		Member mockMember = mock(Member.class);
 		given(mockMember.getId()).willReturn(1L);
 
@@ -277,7 +274,7 @@ class OAuthServiceTest {
 			.withIssuedAt(new Date())
 			.sign(Algorithm.RSA256(rsaPublicKey, rsaPrivateKey));
 
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, mockAuthCode, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, mockAuthCode, null);
 		Member mockMember = mock(Member.class);
 		given(mockMember.getId()).willReturn(1L);
 
@@ -324,7 +321,7 @@ class OAuthServiceTest {
 			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.setBody("{\"keys\": [{\"kid\": \"different-kid\"}]}"));
 
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, null, mockIdToken);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, null, mockIdToken);
 
 		// when & then
 		assertThatThrownBy(() -> oAuthService.oauthLogin(request))
@@ -336,7 +333,7 @@ class OAuthServiceTest {
 	@DisplayName("다양한 HTTP 상태코드에 따른 에러 처리")
 	void handle_error_response_with_different_status() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "invalid-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "invalid-token", null, null);
 
 		// 401 Unauthorized
 		mockWebServer.enqueue(new MockResponse()
@@ -363,7 +360,7 @@ class OAuthServiceTest {
 			.setResponseCode(500)  // JWKS 엔드포인트 실패
 			.setBody("Server Error"));
 
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, null, validToken);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, null, validToken);
 
 		// when & then
 		assertThatThrownBy(() -> oAuthService.oauthLogin(request))
@@ -385,7 +382,7 @@ class OAuthServiceTest {
 			.setResponseCode(200)
 			.setBody("invalid json"));  // 잘못된 JSON 형식
 
-		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, null, null, validToken);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, null, validToken);
 
 		// when & then
 		assertThatThrownBy(() -> oAuthService.oauthLogin(request))

--- a/src/test/java/com/tnt/domain/member/MemberIntegrationTest.java
+++ b/src/test/java/com/tnt/domain/member/MemberIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.tnt.domain.member;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 

--- a/src/test/java/com/tnt/domain/member/MemberTest.java
+++ b/src/test/java/com/tnt/domain/member/MemberTest.java
@@ -1,7 +1,6 @@
 package com.tnt.domain.member;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -101,6 +100,34 @@ class MemberTest {
 
 			// then
 			assertThat(timestamp).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+		}
+
+		@Test
+		@DisplayName("FCM 토큰 갱신 성공")
+		void update_fcm_token_success() {
+			// given
+			Member member = Member.builder()
+				.id(TSID.fast().toLong())  // TSID 직접 생성
+				.socialId("12345")
+				.fcmToken("old-fcm-token")
+				.email("test@example.com")
+				.name("홍길동")
+				.birthday(LocalDate.parse("2022-01-01"))
+				.profileImageUrl("http://example.com")
+				.serviceAgreement(true)
+				.collectionAgreement(true)
+				.advertisementAgreement(true)
+				.pushAgreement(true)
+				.socialType(SocialType.KAKAO)
+				.build();
+
+			String newFcmToken = "new-fcm-token";
+
+			// when
+			member.updateFcmTokenIfExpired(newFcmToken);
+
+			// then
+			assertThat(member.getFcmToken()).isEqualTo(newFcmToken);
 		}
 	}
 }

--- a/src/test/java/com/tnt/presentation/member/AuthenticationControllerTest.java
+++ b/src/test/java/com/tnt/presentation/member/AuthenticationControllerTest.java
@@ -1,12 +1,8 @@
 package com.tnt.presentation.member;
 
-import static com.tnt.global.error.model.ErrorMessage.FAILED_TO_FETCH_USER_INFO;
-import static com.tnt.global.error.model.ErrorMessage.MEMBER_NOT_FOUND;
-import static com.tnt.global.error.model.ErrorMessage.UNSUPPORTED_SOCIAL_TYPE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.verify;
+import static com.tnt.global.error.model.ErrorMessage.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,12 +30,7 @@ class AuthenticationControllerTest {
 	@DisplayName("Kakao 로그인 성공")
 	void kakao_login_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"KAKAO",
-			"test-kakao-access-token",
-			null,
-			null
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "test-kakao-access-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willReturn(new OAuthLoginResponse("123456789", "", true));
 
@@ -55,12 +46,7 @@ class AuthenticationControllerTest {
 	@DisplayName("ANDROID - Apple 로그인 성공")
 	void apple_login_with_android_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"APPLE",
-			null,
-			null,
-			"test-id-token"
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm", null, null, "test-id-token");
 
 		given(oauthService.oauthLogin(request)).willReturn(new OAuthLoginResponse("123456789", "", true));
 
@@ -76,12 +62,7 @@ class AuthenticationControllerTest {
 	@DisplayName("iOS - Apple 로그인 성공")
 	void apple_login_with_ios_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"APPLE",
-			null,
-			"test-authorization-code",
-			null
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm", null, "test-authorization-code", null);
 
 		given(oauthService.oauthLogin(request)).willReturn(new OAuthLoginResponse("123456789", "", true));
 
@@ -97,12 +78,7 @@ class AuthenticationControllerTest {
 	@DisplayName("지원하지 않는 소셜 타입일 경우 예외 발생")
 	void unsupported_social_type_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"NAVER",
-			"test-access-token",
-			null,
-			null
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("NAVER", "fcm", "test-access-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willThrow(new OAuthException(UNSUPPORTED_SOCIAL_TYPE));
 
@@ -116,12 +92,7 @@ class AuthenticationControllerTest {
 	@DisplayName("OAuth 서버 에러 시 예외 발생")
 	void oauth_server_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"KAKAO",
-			"invalid-token",
-			null,
-			null
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "invalid-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willThrow(new OAuthException(FAILED_TO_FETCH_USER_INFO));
 
@@ -135,12 +106,7 @@ class AuthenticationControllerTest {
 	@DisplayName("신규 회원일 때 예외 발생")
 	void member_not_found_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest(
-			"KAKAO",
-			"test-token",
-			null,
-			null
-		);
+		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "test-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willThrow(new NotFoundException(MEMBER_NOT_FOUND));
 


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #18 

**✅ Tasks**

- FCM 토큰과 메시지 내용으로 보내는 FcmAdapter를 작성했습니다.
- 추후에 Topic 기반으로 보내는 기능도 확장할 수 있습니다.
- 로그인 시 사용자의 기존 FCM 토큰과 비교하고 기존과 다를 시 교체하도록 OAuth login을 살짝 수정했습니다.

**🙋🏻 More**

- FCM 토큰은 회원가입과 로그인 시 받을 예정입니다. (로그인은 구현 완료)
