### PR TITLE
[#22] hotfix: 소셜 로그인 관련 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ sonar {
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.exclusions", "**/*Application*.java, **/*Config*.java, **/*GlobalExceptionHandler.java, **/Q*.java, **/DynamicQuery.java, " +
-                "**/*Exception.java, **/*Adapter.java"
+                "**/*Exception.java, **/*Adapter.java, **/CustomOAuth2UserService.java"
         property "sonar.java.coveragePlugin", "jacoco"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -117,10 +117,11 @@ jacocoTestCoverageVerification {
                     '*.*Config',
                     '*.error.*',
                     '*.dto.*',
-                    '*.*AppleEcdsaKeyProvider',
+                    '*.CustomOAuth2UserService',
+                    '*.AppleEcdsaKeyProvider',
                     '*.Q*',
                     '*.DynamicQuery',
-                    '*.*Adapter'
+                    '*.*Adapter',
             ]
         }
     }
@@ -142,6 +143,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // TSID
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.0'

--- a/src/main/java/com/tnt/application/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/tnt/application/auth/CustomOAuth2UserService.java
@@ -1,0 +1,28 @@
+package com.tnt.application.auth;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		log.info("socialAccessToken: {}", userRequest.getAccessToken().getTokenValue());
+
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+		return new DefaultOAuth2User(null, oAuth2User.getAttributes(), null);
+	}
+}

--- a/src/main/java/com/tnt/application/member/OAuthService.java
+++ b/src/main/java/com/tnt/application/member/OAuthService.java
@@ -1,5 +1,7 @@
 package com.tnt.application.member;
 
+import static com.tnt.domain.constant.Constant.APPLE;
+import static com.tnt.domain.constant.Constant.KAKAO;
 import static com.tnt.global.error.model.ErrorMessage.*;
 import static java.util.Objects.isNull;
 
@@ -50,9 +52,6 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class OAuthService {
 
-	private static final String KAKAO = "KAKAO";
-	private static final String APPLE = "APPLE";
-
 	private final WebClient webClient;
 	private final SessionService sessionService;
 	private final MemberRepository memberRepository;
@@ -65,13 +64,10 @@ public class OAuthService {
 
 	@Value("${social-login.provider.apple.team-id}")
 	private String teamId;
-
 	@Value("${social-login.provider.apple.client-id}")
 	private String clientId;
-
 	@Value("${social-login.provider.apple.key-id}")
 	private String keyId;
-
 	@Value("${social-login.provider.apple.private-key}")
 	private String privateKey;
 

--- a/src/main/java/com/tnt/domain/constant/Constant.java
+++ b/src/main/java/com/tnt/domain/constant/Constant.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constant {
 
+	public static final String KAKAO = "KAKAO";
+	public static final String APPLE = "APPLE";
 	public static final String TRAINER = "trainer";
 	public static final String TRAINEE = "trainee";
 	public static final String TRAINER_DEFAULT_IMAGE = "https://images.tntapp.co.kr/profiles/trainers/basic_profile_trainer.svg";

--- a/src/main/java/com/tnt/dto/member/request/OAuthLoginRequest.java
+++ b/src/main/java/com/tnt/dto/member/request/OAuthLoginRequest.java
@@ -1,5 +1,8 @@
 package com.tnt.dto.member.request;
 
+import static com.tnt.domain.constant.Constant.APPLE;
+import static com.tnt.domain.constant.Constant.KAKAO;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
@@ -28,7 +31,7 @@ public record OAuthLoginRequest(
 
 	@AssertTrue(message = "카카오 로그인 시 소셜 액세스 토큰은 필수입니다.")
 	public boolean validateKakaoLogin() {
-		if ("KAKAO".equals(socialType)) {
+		if (KAKAO.equals(socialType)) {
 			return socialAccessToken != null && !socialAccessToken.isBlank();
 		}
 
@@ -37,7 +40,7 @@ public record OAuthLoginRequest(
 
 	@AssertTrue(message = "애플 로그인 시 인가 코드 또는 ID 토큰 중 하나는 필수입니다.")
 	public boolean validateAppleLogin() {
-		if ("APPLE".equals(socialType)) {
+		if (APPLE.equals(socialType)) {
 			return (authorizationCode != null && !authorizationCode.isBlank()) || (idToken != null
 				&& !idToken.isBlank());
 		}

--- a/src/main/java/com/tnt/global/config/SecurityConfig.java
+++ b/src/main/java/com/tnt/global/config/SecurityConfig.java
@@ -34,7 +34,6 @@ public class SecurityConfig {
 		"/api",
 		"/v3/api-docs/**",
 		"/swagger-ui/**",
-		"/oauth/**",
 		"/members/sign-up"
 	};
 	private final CustomOAuth2UserService customOAuth2UserService;

--- a/src/main/java/com/tnt/global/config/SecurityConfig.java
+++ b/src/main/java/com/tnt/global/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
+import com.tnt.application.auth.CustomOAuth2UserService;
 import com.tnt.application.auth.SessionService;
 import com.tnt.global.auth.filter.ServletExceptionFilter;
 import com.tnt.global.auth.filter.SessionAuthenticationFilter;
@@ -28,12 +29,15 @@ public class SecurityConfig {
 
 	private static final String[] ALLOWED_URIS = {
 		"/",
+		"/oauth2/**",
+		"/login/**",
 		"/api",
 		"/v3/api-docs/**",
 		"/swagger-ui/**",
-		"/login/**",
+		"/oauth/**",
 		"/members/sign-up"
 	};
+	private final CustomOAuth2UserService customOAuth2UserService;
 	private final SessionService sessionService;
 
 	@Bean
@@ -43,14 +47,12 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
-			.headers(headers ->
-				headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-			.sessionManagement(sessionManagement ->
-				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-			)
-			.authorizeHttpRequests(request ->
-				request.requestMatchers(ALLOWED_URIS).permitAll()
-					.anyRequest().authenticated())
+			.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+			.sessionManagement(sessionManagement -> sessionManagement
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)))
+			.authorizeHttpRequests(request -> request
+				.requestMatchers(ALLOWED_URIS).permitAll().anyRequest().authenticated())
 			.addFilterBefore(servletExceptionFilter(), LogoutFilter.class)
 			.addFilterAfter(sessionAuthenticationFilter(), LogoutFilter.class);
 

--- a/src/main/java/com/tnt/presentation/member/AuthenticationController.java
+++ b/src/main/java/com/tnt/presentation/member/AuthenticationController.java
@@ -24,7 +24,7 @@ public class AuthenticationController {
 	private final OAuthService oauthService;
 
 	@Operation(summary = "소셜 로그인 API")
-	@PostMapping("/oauth/login")
+	@PostMapping("/login")
 	@ResponseStatus(value = OK)
 	public OAuthLoginResponse oauthLogin(@RequestBody @Valid OAuthLoginRequest request) {
 		return oauthService.oauthLogin(request);

--- a/src/main/java/com/tnt/presentation/member/AuthenticationController.java
+++ b/src/main/java/com/tnt/presentation/member/AuthenticationController.java
@@ -24,7 +24,7 @@ public class AuthenticationController {
 	private final OAuthService oauthService;
 
 	@Operation(summary = "소셜 로그인 API")
-	@PostMapping("/login/oauth")
+	@PostMapping("/oauth/login")
 	@ResponseStatus(value = OK)
 	public OAuthLoginResponse oauthLogin(@RequestBody @Valid OAuthLoginRequest request) {
 		return oauthService.oauthLogin(request);

--- a/src/test/java/com/tnt/application/member/OAuthServiceTest.java
+++ b/src/test/java/com/tnt/application/member/OAuthServiceTest.java
@@ -1,5 +1,7 @@
 package com.tnt.application.member;
 
+import static com.tnt.domain.constant.Constant.APPLE;
+import static com.tnt.domain.constant.Constant.KAKAO;
 import static com.tnt.global.error.model.ErrorMessage.APPLE_AUTH_ERROR;
 import static com.tnt.global.error.model.ErrorMessage.FAILED_TO_FETCH_USER_INFO;
 import static com.tnt.global.error.model.ErrorMessage.UNSUPPORTED_SOCIAL_TYPE;
@@ -46,15 +48,10 @@ import okhttp3.mockwebserver.MockWebServer;
 @ExtendWith(MockitoExtension.class)
 class OAuthServiceTest {
 
-	private static final String KAKAO = "KAKAO";
-	private static final String APPLE = "APPLE";
-
 	private MockWebServer mockWebServer;
 	private OAuthService oAuthService;
-
 	@Mock
 	private SessionService sessionService;
-
 	@Mock
 	private MemberRepository memberRepository;
 

--- a/src/test/java/com/tnt/presentation/member/AuthenticationControllerTest.java
+++ b/src/test/java/com/tnt/presentation/member/AuthenticationControllerTest.java
@@ -1,5 +1,7 @@
 package com.tnt.presentation.member;
 
+import static com.tnt.domain.constant.Constant.APPLE;
+import static com.tnt.domain.constant.Constant.KAKAO;
 import static com.tnt.global.error.model.ErrorMessage.FAILED_TO_FETCH_USER_INFO;
 import static com.tnt.global.error.model.ErrorMessage.MEMBER_NOT_FOUND;
 import static com.tnt.global.error.model.ErrorMessage.UNSUPPORTED_SOCIAL_TYPE;
@@ -35,7 +37,7 @@ class AuthenticationControllerTest {
 	@DisplayName("Kakao 로그인 성공")
 	void kakao_login_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "test-kakao-access-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "test-kakao-access-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willReturn(
 			new OAuthLoginResponse("123456789", "", "", null, true));
@@ -52,7 +54,7 @@ class AuthenticationControllerTest {
 	@DisplayName("ANDROID - Apple 로그인 성공")
 	void apple_login_with_android_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm", null, null, "test-id-token");
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, null, "test-id-token");
 
 		given(oauthService.oauthLogin(request)).willReturn(new OAuthLoginResponse("123456789", "", "", null, true));
 
@@ -68,7 +70,7 @@ class AuthenticationControllerTest {
 	@DisplayName("iOS - Apple 로그인 성공")
 	void apple_login_with_ios_success() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm", null, "test-authorization-code", null);
+		OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm", null, "test-authorization-code", null);
 
 		given(oauthService.oauthLogin(request)).willReturn(
 			new OAuthLoginResponse("123456789", "", "", null, true));
@@ -99,7 +101,7 @@ class AuthenticationControllerTest {
 	@DisplayName("OAuth 서버 에러 시 예외 발생")
 	void oauth_server_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "invalid-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "invalid-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willThrow(new OAuthException(FAILED_TO_FETCH_USER_INFO));
 
@@ -113,7 +115,7 @@ class AuthenticationControllerTest {
 	@DisplayName("신규 회원일 때 예외 발생")
 	void member_not_found_error() {
 		// given
-		OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm", "test-token", null, null);
+		OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm", "test-token", null, null);
 
 		given(oauthService.oauthLogin(request)).willThrow(new NotFoundException(MEMBER_NOT_FOUND));
 
@@ -131,7 +133,7 @@ class AuthenticationControllerTest {
 		@DisplayName("카카오 로그인 시 socialAccessToken이 없으면 실패")
 		void kakao_login_without_access_token_fail() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm-token", null, null, null);
+			OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm-token", null, null, null);
 
 			// when & then
 			assertThat(request.validateKakaoLogin()).isFalse();
@@ -141,7 +143,7 @@ class AuthenticationControllerTest {
 		@DisplayName("카카오 로그인 시 socialAccessToken이 blank이면 실패")
 		void kakao_login_with_blank_access_token_fail() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm-token", " ", null, null);
+			OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm-token", " ", null, null);
 
 			// when & then
 			assertThat(request.validateKakaoLogin()).isFalse();
@@ -151,17 +153,25 @@ class AuthenticationControllerTest {
 		@DisplayName("카카오 로그인 시 socialAccessToken이 있으면 성공")
 		void kakao_login_with_access_token_success() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("KAKAO", "fcm-token", "valid-token", null, null);
+			OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm-token", "valid-token", null, null);
 
 			// when & then
 			assertThat(request.validateKakaoLogin()).isTrue();
 		}
 
 		@Test
+		@DisplayName("카카오 로그인 시 validateAppleLogin은 true 반환")
+		void kakao_login_with_validateAppleLogin_method_success() {
+			OAuthLoginRequest request = new OAuthLoginRequest(KAKAO, "fcm-token", "access-token", null, null);
+
+			assertThat(request.validateAppleLogin()).isTrue();
+		}
+
+		@Test
 		@DisplayName("애플 로그인 시 authorizationCode와 idToken이 모두 없으면 실패")
 		void apple_login_without_code_and_token_fail() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm-token", null, null, null);
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, null, null);
 
 			// when & then
 			assertThat(request.validateAppleLogin()).isFalse();
@@ -171,7 +181,7 @@ class AuthenticationControllerTest {
 		@DisplayName("애플 로그인 시 authorizationCode만 있어도 성공")
 		void apple_login_with_authorization_code_success() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm-token", null, "valid-auth-code", null);
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, "valid-auth-code", null);
 
 			// when & then
 			assertThat(request.validateAppleLogin()).isTrue();
@@ -181,7 +191,7 @@ class AuthenticationControllerTest {
 		@DisplayName("애플 로그인 시 idToken만 있어도 성공")
 		void apple_login_with_id_token_success() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm-token", null, null, "valid-id-token");
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, null, "valid-id-token");
 
 			// when & then
 			assertThat(request.validateAppleLogin()).isTrue();
@@ -191,7 +201,7 @@ class AuthenticationControllerTest {
 		@DisplayName("애플 로그인 시 authorizationCode와 idToken이 모두 있어도 성공")
 		void apple_login_with_code_and_token_success() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm-token", null, "valid-auth-code",
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, "valid-auth-code",
 				"valid-id-token");
 
 			// when & then
@@ -202,10 +212,18 @@ class AuthenticationControllerTest {
 		@DisplayName("애플 로그인 시 blank 토큰은 실패")
 		void apple_login_with_blank_token_fail() {
 			// given
-			OAuthLoginRequest request = new OAuthLoginRequest("APPLE", "fcm-token", null, " ", " ");
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, " ", " ");
 
 			// when & then
 			assertThat(request.validateAppleLogin()).isFalse();
+		}
+
+		@Test
+		@DisplayName("애플 로그인 시 validateKakaoLogin()은 true 반환")
+		void apple_login_with_validateKakaoLogin_method_success() {
+			OAuthLoginRequest request = new OAuthLoginRequest(APPLE, "fcm-token", null, "auth-code", null);
+
+			assertThat(request.validateKakaoLogin()).isTrue();
 		}
 	}
 }


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #22 

**✅ Tasks**
소셜 로그인 로컬에서 테스트 시
카카오 로그인 기준으로
1. /oauth2/authorization/kakao 로 접속하고 카카오 로그인 후
2. IDE에서 socialAccessToken 로그 찍히는데,
3. 그걸로 로그인 api, 회원가입 api 테스트 가능합니다.

**🙋🏻 More**

- 참고 내용
