### PR TITLE
[#28] hotfix: 생일 미저장, push 알림 동의 삭제

### DIFF
--- a/src/main/java/com/tnt/application/member/MemberService.java
+++ b/src/main/java/com/tnt/application/member/MemberService.java
@@ -1,9 +1,14 @@
 package com.tnt.application.member;
 
-import static com.tnt.domain.constant.Constant.*;
-import static com.tnt.global.error.model.ErrorMessage.*;
-import static io.hypersistence.tsid.TSID.Factory.*;
-import static io.micrometer.common.util.StringUtils.*;
+import static com.tnt.domain.constant.Constant.TRAINEE;
+import static com.tnt.domain.constant.Constant.TRAINEE_DEFAULT_IMAGE;
+import static com.tnt.domain.constant.Constant.TRAINER;
+import static com.tnt.domain.constant.Constant.TRAINER_DEFAULT_IMAGE;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_CONFLICT;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_NOT_FOUND;
+import static com.tnt.global.error.model.ErrorMessage.UNSUPPORTED_MEMBER_TYPE;
+import static io.hypersistence.tsid.TSID.Factory.getTsid;
+import static io.micrometer.common.util.StringUtils.isNotBlank;
 
 import java.util.List;
 
@@ -77,10 +82,10 @@ public class MemberService {
 			.email(request.socialEmail())
 			.name(request.name())
 			.profileImageUrl(defaultImageUrl)
+			.birthday(request.birthday())
 			.serviceAgreement(request.serviceAgreement())
 			.collectionAgreement(request.collectionAgreement())
 			.advertisementAgreement(request.advertisementAgreement())
-			.pushAgreement(request.pushAgreement())
 			.socialType(SocialType.valueOf(request.socialType()))
 			.build();
 

--- a/src/main/java/com/tnt/domain/constant/Constant.java
+++ b/src/main/java/com/tnt/domain/constant/Constant.java
@@ -12,6 +12,7 @@ public class Constant {
 	public static final String TRAINEE = "trainee";
 	public static final String TRAINER_DEFAULT_IMAGE = "https://images.tntapp.co.kr/profiles/trainers/basic_profile_trainer.svg";
 	public static final String TRAINEE_DEFAULT_IMAGE = "https://images.tntapp.co.kr/profiles/trainees/basic_profile_trainee.svg";
+	public static final String IMAGE_BASE_URL = "https://images.tntapp.co.kr/";
 	public static final String TRAINER_S3_PROFILE_PATH = "profiles/trainers";
 	public static final String TRAINEE_S3_PROFILE_PATH = "profiles/trainees";
 }

--- a/src/main/java/com/tnt/domain/member/Member.java
+++ b/src/main/java/com/tnt/domain/member/Member.java
@@ -1,6 +1,13 @@
 package com.tnt.domain.member;
 
-import static com.tnt.global.error.model.ErrorMessage.*;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_COLLECTION_AGREEMENT;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_EMAIL;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_NAME;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_PROFILE_IMAGE_URL;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_SERVICE_AGREEMENT;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_SOCIAL_ID;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_INVALID_SOCIAL_TYPE;
+import static com.tnt.global.error.model.ErrorMessage.MEMBER_NULL_ADVERTISEMENT_AGREEMENT;
 import static io.micrometer.common.util.StringUtils.isBlank;
 import static java.lang.Boolean.FALSE;
 import static java.util.Objects.isNull;
@@ -67,9 +74,6 @@ public class Member extends BaseTimeEntity {
 	@Column(name = "advertisement_agreement", nullable = false)
 	private Boolean advertisementAgreement;
 
-	@Column(name = "push_agreement", nullable = false)
-	private Boolean pushAgreement;
-
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
 
@@ -80,7 +84,7 @@ public class Member extends BaseTimeEntity {
 	@Builder
 	public Member(Long id, String socialId, String fcmToken, String email, String name, String profileImageUrl,
 		LocalDate birthday, Boolean serviceAgreement, Boolean collectionAgreement, Boolean advertisementAgreement,
-		Boolean pushAgreement, SocialType socialType) {
+		SocialType socialType) {
 		validateRequiredAgreements(serviceAgreement, collectionAgreement);
 
 		this.id = id;
@@ -94,7 +98,6 @@ public class Member extends BaseTimeEntity {
 		this.collectionAgreement = collectionAgreement;
 		this.advertisementAgreement = requireNonNull(advertisementAgreement,
 			MEMBER_NULL_ADVERTISEMENT_AGREEMENT.getMessage());
-		this.pushAgreement = requireNonNull(pushAgreement, MEMBER_NULL_PUSH_AGREEMENT.getMessage());
 		this.socialType = validateSocialType(socialType);
 	}
 

--- a/src/main/java/com/tnt/dto/member/request/SignUpRequest.java
+++ b/src/main/java/com/tnt/dto/member/request/SignUpRequest.java
@@ -46,10 +46,6 @@ public record SignUpRequest(
 	@NotNull(message = "광고성 알림 수신 동의 여부는 필수입니다.")
 	Boolean advertisementAgreement,
 
-	@Schema(description = "푸쉬 알림 수신 동의 여부", example = "true", nullable = false)
-	@NotNull(message = "푸쉬 알림 수신 동의 여부는 필수입니다.")
-	Boolean pushAgreement,
-
 	@Schema(description = "회원 이름", example = "홍길동", nullable = false)
 	@NotBlank(message = "회원 이름은 필수입니다.")
 	String name,

--- a/src/main/java/com/tnt/infrastructure/s3/S3Adapter.java
+++ b/src/main/java/com/tnt/infrastructure/s3/S3Adapter.java
@@ -1,5 +1,6 @@
 package com.tnt.infrastructure.s3;
 
+import static com.tnt.domain.constant.Constant.IMAGE_BASE_URL;
 import static com.tnt.global.error.model.ErrorMessage.S3_UPLOAD_ERROR;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -11,7 +12,6 @@ import io.hypersistence.tsid.TSID;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -37,18 +37,9 @@ public class S3Adapter {
 
 			s3Client.putObject(request, RequestBody.fromBytes(fileData));
 
-			return getUrl(s3Key);
+			return IMAGE_BASE_URL + s3Key;
 		} catch (S3Exception e) {
 			throw new ImageException(S3_UPLOAD_ERROR, e);
 		}
-	}
-
-	private String getUrl(String key) {
-		GetUrlRequest urlRequest = GetUrlRequest.builder()
-			.bucket(bucketName)
-			.key(key)
-			.build();
-
-		return s3Client.utilities().getUrl(urlRequest).toString();
 	}
 }

--- a/src/test/java/com/tnt/application/member/MemberServiceTest.java
+++ b/src/test/java/com/tnt/application/member/MemberServiceTest.java
@@ -79,7 +79,6 @@ class MemberServiceTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 	}
@@ -87,9 +86,9 @@ class MemberServiceTest {
 	@BeforeEach
 	void setUp() {
 		trainerRequest = new SignUpRequest(MOCK_FCM_TOKEN, TRAINER, "KAKAO", MOCK_SOCIAL_ID, MOCK_EMAIL, true, true,
-			true, true, MOCK_NAME, null, null, null, null, null);
+			true, MOCK_NAME, null, null, null, null, null);
 		traineeRequest = new SignUpRequest(MOCK_FCM_TOKEN, TRAINEE, "KAKAO", MOCK_SOCIAL_ID, MOCK_EMAIL, true, true,
-			true, true, MOCK_NAME, null, 180.0, 75.0, MOCK_CAUTION, MOCK_GOALS);
+			true, MOCK_NAME, null, 180.0, 75.0, MOCK_CAUTION, MOCK_GOALS);
 
 		mockTrainerMember = createMockMember(1L, TRAINER_DEFAULT_IMAGE);
 		mockTraineeMember = createMockMember(2L, TRAINEE_DEFAULT_IMAGE);
@@ -169,7 +168,7 @@ class MemberServiceTest {
 		void save_member_unsupported_type_fail() {
 			// given
 			SignUpRequest invalidRequest = new SignUpRequest(MOCK_FCM_TOKEN, "invalid_type", "KAKAO", MOCK_SOCIAL_ID,
-				MOCK_EMAIL, true, true, true, true, MOCK_NAME, null, null, null, null, null);
+				MOCK_EMAIL, true, true, true, MOCK_NAME, null, null, null, null, null);
 
 			// when & then
 			assertThrows(IllegalArgumentException.class, () -> memberService.signUp(invalidRequest));

--- a/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
+++ b/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
@@ -54,7 +54,6 @@ class TrainerServiceTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -108,7 +107,6 @@ class TrainerServiceTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -152,7 +150,6 @@ class TrainerServiceTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 

--- a/src/test/java/com/tnt/domain/member/MemberIntegrationTest.java
+++ b/src/test/java/com/tnt/domain/member/MemberIntegrationTest.java
@@ -33,7 +33,6 @@ class MemberIntegrationTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 

--- a/src/test/java/com/tnt/domain/member/MemberTest.java
+++ b/src/test/java/com/tnt/domain/member/MemberTest.java
@@ -40,7 +40,6 @@ class MemberTest {
 				.serviceAgreement(true)
 				.collectionAgreement(true)
 				.advertisementAgreement(true)
-				.pushAgreement(true)
 				.socialType(SocialType.KAKAO)
 				.build();
 
@@ -65,7 +64,6 @@ class MemberTest {
 					.serviceAgreement(true)
 					.collectionAgreement(true)
 					.advertisementAgreement(true)
-					.pushAgreement(true)
 					.socialType(SocialType.KAKAO)
 					.build())
 				.map(Member::getId)
@@ -95,7 +93,6 @@ class MemberTest {
 				.serviceAgreement(true)
 				.collectionAgreement(true)
 				.advertisementAgreement(true)
-				.pushAgreement(true)
 				.socialType(SocialType.KAKAO)
 				.build();
 			TSID tsid = TSID.from(member.getId());
@@ -120,7 +117,6 @@ class MemberTest {
 				.serviceAgreement(true)
 				.collectionAgreement(true)
 				.advertisementAgreement(true)
-				.pushAgreement(true)
 				.socialType(SocialType.KAKAO)
 				.build();
 

--- a/src/test/java/com/tnt/fixture/MemberFixture.java
+++ b/src/test/java/com/tnt/fixture/MemberFixture.java
@@ -25,7 +25,6 @@ public final class MemberFixture {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 	}
@@ -48,7 +47,6 @@ public final class MemberFixture {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 	}

--- a/src/test/java/com/tnt/infrastructure/s3/S3AdapterTest.java
+++ b/src/test/java/com/tnt/infrastructure/s3/S3AdapterTest.java
@@ -6,9 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import java.net.URI;
-import java.net.URL;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +20,6 @@ import com.tnt.global.error.exception.ImageException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -51,16 +47,12 @@ class S3AdapterTest {
 		byte[] fileData = "test data".getBytes();
 		String folderPath = "test/folder";
 		String extension = "jpg";
-		URL mockUrl = URI.create("https://test-bucket.s3.amazonaws.com/test/folder/123.jpg").toURL();
-
-		given(s3Client.utilities()).willReturn(s3Utilities);
-		given(s3Utilities.getUrl(any(GetUrlRequest.class))).willReturn(mockUrl);
 
 		// when
 		String result = s3Adapter.uploadFile(fileData, folderPath, extension);
 
 		// then
-		assertThat(result).startsWith("https://test-bucket.s3.amazonaws.com/test/folder/");
+		assertThat(result).startsWith("https://images.tntapp.co.kr/test/folder/");
 		verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 	}
 

--- a/src/test/java/com/tnt/presentation/member/MemberControllerTest.java
+++ b/src/test/java/com/tnt/presentation/member/MemberControllerTest.java
@@ -1,9 +1,15 @@
 package com.tnt.presentation.member;
 
-import static com.tnt.domain.constant.Constant.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static com.tnt.domain.constant.Constant.TRAINEE;
+import static com.tnt.domain.constant.Constant.TRAINEE_DEFAULT_IMAGE;
+import static com.tnt.domain.constant.Constant.TRAINER;
+import static com.tnt.domain.constant.Constant.TRAINER_DEFAULT_IMAGE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -40,7 +46,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 	void sign_up_trainer_success() throws Exception {
 		// given
 		SignUpRequest request = new SignUpRequest("fcm-token-test", TRAINER, "KAKAO", "12345", "test@kakao.com", true,
-			true, true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
+			true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
 
 		// when
 		var jsonRequest = new MockMultipartFile("request", "", APPLICATION_JSON_VALUE,
@@ -63,7 +69,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 	void sign_up_trainee_success() throws Exception {
 		// given
 		SignUpRequest request = new SignUpRequest("fcm-token-test", TRAINEE, "KAKAO", "12345", "test@kakao.com", true,
-			true, true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
+			true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
 
 		// when
 		var jsonRequest = new MockMultipartFile("request", "", APPLICATION_JSON_VALUE,
@@ -87,7 +93,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 		// given
 		SignUpRequest request = new SignUpRequest("fcm-token-test", "invalid_type", "KAKAO", "12345", "test@kakao.com",
 			true,
-			true, true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
+			true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
 
 		// when
 		var jsonRequest = new MockMultipartFile("request", "", APPLICATION_JSON_VALUE,
@@ -106,7 +112,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 	void sign_up_missing_required_field_fail() throws Exception {
 		// given
 		SignUpRequest request = new SignUpRequest("", TRAINER, "KAKAO", "12345", "test@kakao.com", true,
-			true, true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
+			true, true, "홍길동", LocalDate.of(1990, 1, 1), 175.0, 70.0, "테스트 주의사항", List.of("체중 감량", "근력 향상"));
 
 		// when
 		var jsonRequest = new MockMultipartFile("request", "", APPLICATION_JSON_VALUE,

--- a/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
@@ -86,7 +86,6 @@ class TrainerControllerTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -120,7 +119,6 @@ class TrainerControllerTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -154,7 +152,6 @@ class TrainerControllerTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -187,7 +184,6 @@ class TrainerControllerTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 
@@ -224,7 +220,6 @@ class TrainerControllerTest {
 			.serviceAgreement(true)
 			.collectionAgreement(true)
 			.advertisementAgreement(true)
-			.pushAgreement(true)
 			.socialType(SocialType.KAKAO)
 			.build();
 


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #28 

**✅ Tasks**

- 생일이 저장되지 않는 현상을 고쳤습니다.
- push 알람 여부는 클라이언트에서 관리하여 관련 정보는 DB에서 저장하지 않도록 했습니다.

**🙋🏻 More**
