### PR TITLE
[#38] hotfix: 탈퇴 후 재가입 안되는 현상

### DIFF
--- a/src/main/java/com/tnt/application/member/MemberService.java
+++ b/src/main/java/com/tnt/application/member/MemberService.java
@@ -2,6 +2,7 @@ package com.tnt.application.member;
 
 import static com.tnt.common.error.model.ErrorMessage.MEMBER_CONFLICT;
 import static com.tnt.common.error.model.ErrorMessage.MEMBER_NOT_FOUND;
+import static com.tnt.dto.member.MemberProjection.MemberTypeDto;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +11,9 @@ import com.tnt.common.error.exception.ConflictException;
 import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.member.Member;
 import com.tnt.domain.member.SocialType;
+import com.tnt.gateway.dto.response.CheckSessionResponse;
 import com.tnt.infrastructure.mysql.repository.member.MemberRepository;
+import com.tnt.infrastructure.mysql.repository.member.MemberSearchRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final MemberSearchRepository memberSearchRepository;
 
 	public Member getMemberWithMemberId(Long memberId) {
 		return memberRepository.findByIdAndDeletedAtIsNull(memberId)
@@ -40,5 +44,12 @@ public class MemberService {
 	@Transactional
 	public Member saveMember(Member member) {
 		return memberRepository.save(member);
+	}
+
+	public CheckSessionResponse getMemberType(Long memberId) {
+		MemberTypeDto memberTypeDto = memberSearchRepository.findMemberTypeByMemberId(memberId)
+			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+
+		return new CheckSessionResponse(memberTypeDto.memberType());
 	}
 }

--- a/src/main/java/com/tnt/application/member/SignUpService.java
+++ b/src/main/java/com/tnt/application/member/SignUpService.java
@@ -27,7 +27,6 @@ import com.tnt.gateway.service.SessionService;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SignUpService {
 

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -34,7 +34,6 @@ import com.tnt.infrastructure.mysql.repository.pt.PtTrainerTraineeRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PtService {
 
@@ -69,6 +68,7 @@ public class PtService {
 			trainerMember.getProfileImageUrl(), traineeMember.getProfileImageUrl(), trainer.getId(), trainee.getId());
 	}
 
+	@Transactional(readOnly = true)
 	public ConnectWithTraineeResponse getFirstTrainerTraineeConnect(Long memberId, Long trainerId,
 		Long traineeId) {
 		validateIfNotConnected(trainerId, traineeId);
@@ -87,6 +87,7 @@ public class PtService {
 			trainee.getHeight(), trainee.getWeight(), ptGoal, trainee.getCautionNote());
 	}
 
+	@Transactional(readOnly = true)
 	public GetPtLessonsOnDateResponse getPtLessonsOnDate(Long memberId, LocalDate date) {
 		Trainer trainer = trainerService.getTrainerWithMemberId(memberId);
 

--- a/src/main/java/com/tnt/application/trainee/PtGoalService.java
+++ b/src/main/java/com/tnt/application/trainee/PtGoalService.java
@@ -11,7 +11,6 @@ import com.tnt.infrastructure.mysql.repository.pt.PtGoalRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PtGoalService {
 
@@ -21,6 +20,7 @@ public class PtGoalService {
 		return ptGoalRepository.findAllByTraineeIdAndDeletedAtIsNull(traineeId);
 	}
 
+	@Transactional
 	public List<PtGoal> saveAllPtGoals(List<PtGoal> ptGoals) {
 		return ptGoalRepository.saveAll(ptGoals);
 	}

--- a/src/main/java/com/tnt/application/trainee/TraineeService.java
+++ b/src/main/java/com/tnt/application/trainee/TraineeService.java
@@ -13,7 +13,6 @@ import com.tnt.infrastructure.mysql.repository.trainee.TraineeSearchRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TraineeService {
 

--- a/src/main/java/com/tnt/application/trainer/TrainerService.java
+++ b/src/main/java/com/tnt/application/trainer/TrainerService.java
@@ -15,7 +15,6 @@ import com.tnt.infrastructure.mysql.repository.trainer.TrainerSearchRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TrainerService {
 

--- a/src/main/java/com/tnt/domain/member/Member.java
+++ b/src/main/java/com/tnt/domain/member/Member.java
@@ -1,6 +1,12 @@
 package com.tnt.domain.member;
 
-import static com.tnt.common.error.model.ErrorMessage.*;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_COLLECTION_AGREEMENT;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_EMAIL;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_NAME;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_PROFILE_IMAGE_URL;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_SERVICE_AGREEMENT;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_INVALID_SOCIAL_ID;
+import static com.tnt.common.error.model.ErrorMessage.MEMBER_NULL_ADVERTISEMENT_AGREEMENT;
 import static io.micrometer.common.util.StringUtils.isBlank;
 import static java.lang.Boolean.FALSE;
 import static java.util.Objects.isNull;
@@ -41,7 +47,7 @@ public class Member extends BaseTimeEntity {
 	@Column(name = "id", nullable = false, unique = true)
 	private Long id;
 
-	@Column(name = "social_id", nullable = false, unique = true, length = SOCIAL_ID_LENGTH)
+	@Column(name = "social_id", nullable = true, unique = true, length = SOCIAL_ID_LENGTH)
 	private String socialId;
 
 	@Column(name = "fcm_token", nullable = false, length = 255)
@@ -154,6 +160,7 @@ public class Member extends BaseTimeEntity {
 	}
 
 	public void softDelete() {
+		this.socialId = null;
 		this.deletedAt = LocalDateTime.now();
 	}
 

--- a/src/main/java/com/tnt/dto/member/MemberProjection.java
+++ b/src/main/java/com/tnt/dto/member/MemberProjection.java
@@ -1,0 +1,16 @@
+package com.tnt.dto.member;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tnt.domain.member.MemberType;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberProjection {
+
+	@QueryProjection
+	public record MemberTypeDto(MemberType memberType) {
+
+	}
+}

--- a/src/main/java/com/tnt/gateway/controller/AuthenticationController.java
+++ b/src/main/java/com/tnt/gateway/controller/AuthenticationController.java
@@ -2,16 +2,17 @@ package com.tnt.gateway.controller;
 
 import static org.springframework.http.HttpStatus.OK;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tnt.application.member.MemberService;
 import com.tnt.dto.member.response.LogoutResponse;
 import com.tnt.gateway.config.AuthMember;
 import com.tnt.gateway.dto.request.OAuthLoginRequest;
+import com.tnt.gateway.dto.response.CheckSessionResponse;
 import com.tnt.gateway.dto.response.OAuthLoginResponse;
 import com.tnt.gateway.service.OAuthService;
 
@@ -26,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthenticationController {
 
 	private final OAuthService oauthService;
+	private final MemberService memberService;
 
 	@Operation(summary = "소셜 로그인 API")
 	@PostMapping("/login")
@@ -44,7 +46,7 @@ public class AuthenticationController {
 	@Operation(summary = "로그인 세션 유효 확인 API")
 	@GetMapping("/check-session")
 	@ResponseStatus(OK)
-	public ResponseEntity<Void> checkSession() {
-		return new ResponseEntity<>(OK);
+	public CheckSessionResponse checkSession(@AuthMember Long memberId) {
+		return memberService.getMemberType(memberId);
 	}
 }

--- a/src/main/java/com/tnt/gateway/dto/response/CheckSessionResponse.java
+++ b/src/main/java/com/tnt/gateway/dto/response/CheckSessionResponse.java
@@ -1,0 +1,13 @@
+package com.tnt.gateway.dto.response;
+
+import com.tnt.domain.member.MemberType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세션 확인 API 응답")
+public record CheckSessionResponse(
+	@Schema(description = "회원 타입", example = "TRAINER", nullable = false)
+	MemberType memberType
+) {
+
+}

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
@@ -1,0 +1,31 @@
+package com.tnt.infrastructure.mysql.repository.member;
+
+import static com.tnt.domain.member.QMember.member;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tnt.dto.member.MemberProjection;
+import com.tnt.dto.member.QMemberProjection_MemberTypeDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberSearchRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public Optional<MemberProjection.MemberTypeDto> findMemberTypeByMemberId(Long memberId) {
+		return Optional.ofNullable(jpaQueryFactory
+			.select(new QMemberProjection_MemberTypeDto(member.memberType))
+			.from(member)
+			.where(
+				member.id.eq(memberId),
+				member.deletedAt.isNull()
+			)
+			.fetchOne());
+	}
+}

--- a/src/test/java/com/tnt/gateway/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/tnt/gateway/controller/AuthenticationControllerTest.java
@@ -19,34 +19,42 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.tnt.application.member.MemberService;
 import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.common.error.exception.OAuthException;
 import com.tnt.dto.member.response.LogoutResponse;
 import com.tnt.gateway.dto.request.OAuthLoginRequest;
+import com.tnt.gateway.dto.response.CheckSessionResponse;
 import com.tnt.gateway.dto.response.OAuthLoginResponse;
 import com.tnt.gateway.service.OAuthService;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationControllerTest {
 
+	@InjectMocks
+	private AuthenticationController authenticationController;
+
 	@Mock
 	private OAuthService oauthService;
 
-	@InjectMocks
-	private AuthenticationController authenticationController;
+	@Mock
+	private MemberService memberService;
 
 	@Test
 	@DisplayName("로그인 세션 유효 확인 성공")
 	void is_session_valid_success() {
+		// given
+		Long memberId = 1L;
+
+		given(memberService.getMemberType(memberId)).willReturn(new CheckSessionResponse(TRAINER));
+
 		// when
-		ResponseEntity<Void> voidResponseEntity = authenticationController.checkSession();
+		CheckSessionResponse checkSessionResponse = authenticationController.checkSession(memberId);
 
 		// then
-		assertThat(voidResponseEntity.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+		assertThat(checkSessionResponse.memberType()).isEqualTo(TRAINER);
 	}
 
 	@Nested


### PR DESCRIPTION
- 세션 확인 시 회원 타입도 리턴하도록 변경

**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #38 

**✅ Tasks**

- 탈퇴 후 정상적으로 다시 재가입 할 수 있도록 했습니다. -> 탈퇴시 해당 row의 socialId null로 변경
- 세션 확인 때 해당 회원 타입을 리턴하도록 수정했습니다.

**🙋🏻 More**

- Member의 socialId를 nullable로 변경.
- Projection을 이용해서 회원 타입만 조회하도록 했습니다.
