### PR TITLE
[TNT-204] feat: 회원 조회 기능 구현

### DIFF
--- a/src/main/java/com/tnt/application/member/MemberService.java
+++ b/src/main/java/com/tnt/application/member/MemberService.java
@@ -2,6 +2,7 @@ package com.tnt.application.member;
 
 import static com.tnt.common.error.model.ErrorMessage.MEMBER_CONFLICT;
 import static com.tnt.common.error.model.ErrorMessage.MEMBER_NOT_FOUND;
+import static com.tnt.dto.member.MemberProjection.MemberInfoDto;
 import static com.tnt.dto.member.MemberProjection.MemberTypeDto;
 
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import com.tnt.common.error.exception.ConflictException;
 import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.member.Member;
 import com.tnt.domain.member.SocialType;
+import com.tnt.dto.member.response.GetMemberInfoResponse;
 import com.tnt.gateway.dto.response.CheckSessionResponse;
 import com.tnt.infrastructure.mysql.repository.member.MemberRepository;
 import com.tnt.infrastructure.mysql.repository.member.MemberSearchRepository;
@@ -24,14 +26,9 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final MemberSearchRepository memberSearchRepository;
 
-	public Member getMemberWithMemberId(Long memberId) {
-		return memberRepository.findByIdAndDeletedAtIsNull(memberId)
-			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
-	}
-
-	public Member getMemberWithSocialIdAndSocialType(String socialId, SocialType socialType) {
-		return memberRepository.findBySocialIdAndSocialTypeAndDeletedAtIsNull(socialId, socialType)
-			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+	@Transactional
+	public Member saveMember(Member member) {
+		return memberRepository.save(member);
 	}
 
 	public void validateMemberNotExists(String socialId, SocialType socialType) {
@@ -41,15 +38,29 @@ public class MemberService {
 			});
 	}
 
-	@Transactional
-	public Member saveMember(Member member) {
-		return memberRepository.save(member);
+	public GetMemberInfoResponse getMemberInfo(Long memberId) {
+		MemberInfoDto memberInfo = memberSearchRepository.findMemberInfo(memberId)
+			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+
+		return new GetMemberInfoResponse(memberInfo.name(), memberInfo.email(), memberInfo.profileImageUrl(),
+			memberInfo.birthday(), memberInfo.memberType(), memberInfo.socialType(), memberInfo.invitationCode(),
+			memberInfo.height(), memberInfo.weight(), memberInfo.cautionNote(), memberInfo.goalContents());
 	}
 
 	public CheckSessionResponse getMemberType(Long memberId) {
-		MemberTypeDto memberTypeDto = memberSearchRepository.findMemberTypeByMemberId(memberId)
+		MemberTypeDto memberTypeDto = memberSearchRepository.findMemberType(memberId)
 			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
 
 		return new CheckSessionResponse(memberTypeDto.memberType());
+	}
+
+	public Member getMemberWithMemberId(Long memberId) {
+		return memberRepository.findByIdAndDeletedAtIsNull(memberId)
+			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+	}
+
+	public Member getMemberWithSocialIdAndSocialType(String socialId, SocialType socialType) {
+		return memberRepository.findBySocialIdAndSocialTypeAndDeletedAtIsNull(socialId, socialType)
+			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/tnt/application/member/SignUpService.java
+++ b/src/main/java/com/tnt/application/member/SignUpService.java
@@ -5,7 +5,6 @@ import static com.tnt.common.constant.ProfileConstant.TRAINER_DEFAULT_IMAGE;
 import static com.tnt.domain.member.MemberType.TRAINEE;
 import static com.tnt.domain.member.MemberType.TRAINER;
 import static io.hypersistence.tsid.TSID.Factory.getTsid;
-import static io.micrometer.common.util.StringUtils.isNotBlank;
 
 import java.util.List;
 
@@ -77,7 +76,7 @@ public class SignUpService {
 			.member(member)
 			.height(request.height())
 			.weight(request.weight())
-			.cautionNote(isNotBlank(request.cautionNote()) ? request.cautionNote() : "")
+			.cautionNote(request.cautionNote())
 			.build();
 
 		trainee = traineeService.saveTrainee(trainee);

--- a/src/main/java/com/tnt/dto/member/MemberProjection.java
+++ b/src/main/java/com/tnt/dto/member/MemberProjection.java
@@ -1,7 +1,11 @@
 package com.tnt.dto.member;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import com.querydsl.core.annotations.QueryProjection;
 import com.tnt.domain.member.MemberType;
+import com.tnt.domain.member.SocialType;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -13,4 +17,22 @@ public class MemberProjection {
 	public record MemberTypeDto(MemberType memberType) {
 
 	}
+
+	@QueryProjection
+	public record MemberInfoDto(
+		String name,
+		String email,
+		String profileImageUrl,
+		LocalDate birthday,
+		MemberType memberType,
+		SocialType socialType,
+		String invitationCode,
+		Double height,
+		Double weight,
+		String cautionNote,
+		List<String> goalContents
+	) {
+
+	}
+
 }

--- a/src/main/java/com/tnt/dto/member/request/SignUpRequest.java
+++ b/src/main/java/com/tnt/dto/member/request/SignUpRequest.java
@@ -67,7 +67,7 @@ public record SignUpRequest(
 	@Schema(description = "주의사항", example = "가냘퍼요", nullable = true)
 	String cautionNote,
 
-	@Schema(description = "PT 목적들", example = "[\"체중 감량\", \"근력 향상\"]", nullable = true)
+	@Schema(description = "PT 목적들", example = "[\"체중 감량\", \"근력 향상\"]", nullable = false)
 	List<String> goalContents
 ) {
 

--- a/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
@@ -40,7 +40,7 @@ public record GetMemberInfoResponse(
 	@Schema(description = "주의사항", example = "가냘퍼요", nullable = true)
 	String cautionNote,
 
-	@Schema(description = "PT 목적들", example = "[\"체중 감량\", \"근력 향상\"]", nullable = true)
+	@Schema(description = "PT 목적들", example = "[\"체중 감량\", \"근력 향상\"]", nullable = false)
 	List<String> goalContents
 ) {
 

--- a/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
@@ -1,0 +1,47 @@
+package com.tnt.dto.member.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.tnt.domain.member.MemberType;
+import com.tnt.domain.member.SocialType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 조회 API 응답")
+public record GetMemberInfoResponse(
+	@Schema(description = "회원 이름", example = "홍길동", nullable = false)
+	String name,
+
+	@Schema(description = "이메일", example = "zxc098@kakao.com", nullable = false)
+	String email,
+
+	@Schema(description = "프로필 사진 URL", example = "https://images.tntapp.co.kr/profiles/trainers/basic_profile_trainer.svg", nullable = false)
+	String profileImageUrl,
+
+	@Schema(description = "생년월일", example = "2025-01-01", nullable = true)
+	LocalDate birthday,
+
+	@Schema(description = "회원 타입", example = "TRAINER", nullable = false)
+	MemberType memberType,
+
+	@Schema(description = "소셜 타입", example = "TRAINER", nullable = false)
+	SocialType socialType,
+
+	@Schema(description = "트레이너의 초대 코드 (재발급 포함)", example = "2H9DG4X3", nullable = false)
+	String invitationCode,
+
+	@Schema(description = "키 (cm)", example = "180.5", nullable = true)
+	Double height,
+
+	@Schema(description = "몸무게 (kg)", example = "75.5", nullable = true)
+	Double weight,
+
+	@Schema(description = "주의사항", example = "가냘퍼요", nullable = true)
+	String cautionNote,
+
+	@Schema(description = "PT 목적들", example = "[\"체중 감량\", \"근력 향상\"]", nullable = true)
+	List<String> goalContents
+) {
+
+}

--- a/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
@@ -28,7 +28,7 @@ public record GetMemberInfoResponse(
 	@Schema(description = "소셜 타입", example = "TRAINER", nullable = false)
 	SocialType socialType,
 
-	@Schema(description = "트레이너의 초대 코드 (재발급 포함)", example = "2H9DG4X3", nullable = false)
+	@Schema(description = "트레이너 초대 코드", example = "2H9DG4X3", nullable = true)
 	String invitationCode,
 
 	@Schema(description = "키 (cm)", example = "180.5", nullable = true)

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
@@ -1,12 +1,11 @@
 package com.tnt.infrastructure.mysql.repository.member;
 
-import static com.querydsl.core.types.Projections.constructor;
 import static com.tnt.domain.member.QMember.member;
 import static com.tnt.domain.trainee.QPtGoal.ptGoal;
 import static com.tnt.domain.trainee.QTrainee.trainee;
 import static com.tnt.domain.trainer.QTrainer.trainer;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -14,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tnt.dto.member.MemberProjection;
+import com.tnt.dto.member.QMemberProjection_MemberInfoDto;
 import com.tnt.dto.member.QMemberProjection_MemberTypeDto;
 
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class MemberSearchRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	public Optional<MemberProjection.MemberInfoDto> findMemberInfo(Long memberId) {
-		List<MemberProjection.MemberInfoDto> result = jpaQueryFactory
+		Map<Long, MemberProjection.MemberInfoDto> result = jpaQueryFactory
 			.from(member)
 			.leftJoin(trainer).on(trainer.member.id.eq(member.id), trainer.deletedAt.isNull())
 			.leftJoin(trainee).on(trainee.member.id.eq(member.id), trainee.deletedAt.isNull())
@@ -34,14 +34,14 @@ public class MemberSearchRepository {
 				member.id.eq(memberId),
 				member.deletedAt.isNull()
 			)
-			.transform(GroupBy.groupBy(member.id).list(
-				constructor(MemberProjection.MemberInfoDto.class, member.name, member.email, member.profileImageUrl,
-					member.birthday, member.memberType, member.socialType, trainer.invitationCode, trainee.height,
-					trainee.weight, trainee.cautionNote, GroupBy.list(ptGoal.content)
+			.transform(GroupBy.groupBy(member.id).as(
+				new QMemberProjection_MemberInfoDto(member.name, member.email, member.profileImageUrl, member.birthday,
+					member.memberType, member.socialType, trainer.invitationCode, trainee.height, trainee.weight,
+					trainee.cautionNote, GroupBy.list(ptGoal.content)
 				)
 			));
 
-		return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
+		return Optional.ofNullable(result.get(memberId));
 	}
 
 	public Optional<MemberProjection.MemberTypeDto> findMemberType(Long memberId) {

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/member/MemberSearchRepository.java
@@ -1,11 +1,17 @@
 package com.tnt.infrastructure.mysql.repository.member;
 
+import static com.querydsl.core.types.Projections.constructor;
 import static com.tnt.domain.member.QMember.member;
+import static com.tnt.domain.trainee.QPtGoal.ptGoal;
+import static com.tnt.domain.trainee.QTrainee.trainee;
+import static com.tnt.domain.trainer.QTrainer.trainer;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tnt.dto.member.MemberProjection;
 import com.tnt.dto.member.QMemberProjection_MemberTypeDto;
@@ -18,7 +24,27 @@ public class MemberSearchRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public Optional<MemberProjection.MemberTypeDto> findMemberTypeByMemberId(Long memberId) {
+	public Optional<MemberProjection.MemberInfoDto> findMemberInfo(Long memberId) {
+		List<MemberProjection.MemberInfoDto> result = jpaQueryFactory
+			.from(member)
+			.leftJoin(trainer).on(trainer.member.id.eq(member.id), trainer.deletedAt.isNull())
+			.leftJoin(trainee).on(trainee.member.id.eq(member.id), trainee.deletedAt.isNull())
+			.leftJoin(ptGoal).on(ptGoal.traineeId.eq(trainee.id), ptGoal.deletedAt.isNull())
+			.where(
+				member.id.eq(memberId),
+				member.deletedAt.isNull()
+			)
+			.transform(GroupBy.groupBy(member.id).list(
+				constructor(MemberProjection.MemberInfoDto.class, member.name, member.email, member.profileImageUrl,
+					member.birthday, member.memberType, member.socialType, trainer.invitationCode, trainee.height,
+					trainee.weight, trainee.cautionNote, GroupBy.list(ptGoal.content)
+				)
+			));
+
+		return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
+	}
+
+	public Optional<MemberProjection.MemberTypeDto> findMemberType(Long memberId) {
 		return Optional.ofNullable(jpaQueryFactory
 			.select(new QMemberProjection_MemberTypeDto(member.memberType))
 			.from(member)

--- a/src/main/java/com/tnt/presentation/member/MemberController.java
+++ b/src/main/java/com/tnt/presentation/member/MemberController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,12 +13,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.tnt.application.member.MemberService;
 import com.tnt.application.member.SignUpService;
 import com.tnt.application.member.WithdrawService;
 import com.tnt.application.s3.S3Service;
 import com.tnt.dto.member.WithdrawDto;
 import com.tnt.dto.member.request.SignUpRequest;
 import com.tnt.dto.member.request.WithdrawRequest;
+import com.tnt.dto.member.response.GetMemberInfoResponse;
 import com.tnt.dto.member.response.SignUpResponse;
 import com.tnt.gateway.config.AuthMember;
 import com.tnt.gateway.service.OAuthService;
@@ -37,6 +40,7 @@ public class MemberController {
 	private final SignUpService signUpService;
 	private final WithdrawService withdrawService;
 	private final OAuthService oAuthService;
+	private final MemberService memberService;
 
 	@Operation(summary = "회원가입 API")
 	@PostMapping(value = "/sign-up", consumes = MULTIPART_FORM_DATA_VALUE)
@@ -49,7 +53,14 @@ public class MemberController {
 		return signUpService.finishSignUpWithImage(profileImageUrl, memberId, request.memberType());
 	}
 
-	@Operation(summary = "회원탈퇴 API")
+	@Operation(summary = "회원 조회 API")
+	@GetMapping
+	@ResponseStatus(OK)
+	public GetMemberInfoResponse getMemberInfo(@AuthMember Long memberId) {
+		return memberService.getMemberInfo(memberId);
+	}
+
+	@Operation(summary = "회원 탈퇴 API")
 	@PostMapping("/withdraw")
 	@ResponseStatus(OK)
 	public void withdraw(@AuthMember Long memberId, @RequestBody @Valid WithdrawRequest request) {

--- a/src/test/java/com/tnt/application/member/MemberServiceTest.java
+++ b/src/test/java/com/tnt/application/member/MemberServiceTest.java
@@ -142,7 +142,7 @@ class MemberServiceTest {
 		Member member = MemberFixture.getTrainerMember1WithId();
 		Long memberId = member.getId();
 
-		given(memberSearchRepository.findMemberTypeByMemberId(memberId)).willReturn(
+		given(memberSearchRepository.findMemberType(memberId)).willReturn(
 			Optional.of(new MemberProjection.MemberTypeDto(member.getMemberType())));
 
 		// when
@@ -159,7 +159,7 @@ class MemberServiceTest {
 		Member member = MemberFixture.getTrainerMember1WithId();
 		Long memberId = member.getId();
 
-		given(memberSearchRepository.findMemberTypeByMemberId(memberId)).willReturn(Optional.empty());
+		given(memberSearchRepository.findMemberType(memberId)).willReturn(Optional.empty());
 
 		// when & then
 		Assertions.assertThatThrownBy(() -> memberService.getMemberType(memberId))

--- a/src/test/java/com/tnt/fixture/PtGoalsFixture.java
+++ b/src/test/java/com/tnt/fixture/PtGoalsFixture.java
@@ -1,0 +1,21 @@
+package com.tnt.fixture;
+
+import java.util.List;
+
+import com.tnt.domain.trainee.PtGoal;
+
+public class PtGoalsFixture {
+
+	public static List<PtGoal> getPtGoals(Long traineeId) {
+		return List.of(
+			PtGoal.builder()
+				.traineeId(traineeId)
+				.content("체중 감량")
+				.build(),
+			PtGoal.builder()
+				.traineeId(traineeId)
+				.content("근력 향상")
+				.build()
+		);
+	}
+}


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #37 

**✅ Tasks**

회원 조회 API
- 회원 타입(트레이너/트레이니) 기반으로 조회합니다.
- query dsl로 원하는 컬럼만 조회합니다.
  - PtGoal이 한 (트레이니)회원 당 여러 개이므로 ``select``에서 서브쿼리를 사용하는 대신 ``transform``과 ``group by``를 사용해 PtGoal 리스트를 포함한 조회 결과를 원하는 dto로 매핑합니다.

**🙋🏻 More**

- API 응답 예시
```
// 트레이너 회원
{
    "name": "홍길동",
    "email": "ghdrlfehd@naver.com",
    "profileImageUrl": "https://~~",
    "birthday": null,
    "memberType": "TRAINER",
    "socialType": "KAKAO",
    "invitationCode": "89FA1509",
    "height": null,
    "weight": null,
    "cautionNote": null,
    "goalContents": []
}

// 트레이니 회원
{
    "name": "홍길동",
    "email": "ghdrlfehd@naver.com",
    "profileImageUrl": "https://~~",
    "birthday": "2025-02-02",
    "memberType": "TRAINEE",
    "socialType": "KAKAO",
    "invitationCode": null,
    "height": 300.1,
    "weight": 999.0,
    "cautionNote": "힘들어요",
    "goalContents": [
        "체중 감량",
        "근력 향상",
        "체형 교정"
    ]
}
```