### PR TITLE
[TNT-193] 트레이너 달력 표시에 필요한 데이터 요청 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     // Testcontainer
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "org.testcontainers:testcontainers:1.20.4"
     testImplementation "org.testcontainers:junit-jupiter:1.20.4"
 

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -5,9 +5,8 @@ import static com.tnt.common.error.model.ErrorMessage.PT_TRAINER_TRAINEE_ALREADY
 import static com.tnt.common.error.model.ErrorMessage.PT_TRAINER_TRAINEE_NOT_FOUND;
 
 import java.time.LocalDate;
-import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -115,15 +114,14 @@ public class PtService {
 
 		List<PtLesson> ptLessons = ptLessonSearchRepository.findAllByTraineeIdForCalendar(trainer.getId(), year, month);
 
-		Map<LocalDate, Long> lessonCounts = ptLessons.stream()
+		List<CalendarPtLessonCount> counts = ptLessons.stream()
 			.collect(Collectors.groupingBy(
 				lesson -> lesson.getLessonStart().toLocalDate(),
+				LinkedHashMap::new,
 				Collectors.counting()
-			));
-
-		List<CalendarPtLessonCount> counts = lessonCounts.entrySet().stream()
+			))
+			.entrySet().stream()
 			.map(entry -> new CalendarPtLessonCount(entry.getKey(), entry.getValue().intValue()))
-			.sorted(Comparator.comparing(CalendarPtLessonCount::date))
 			.toList();
 
 		return new GetCalendarPtLessonCountResponse(counts);

--- a/src/main/java/com/tnt/application/trainer/TrainerService.java
+++ b/src/main/java/com/tnt/application/trainer/TrainerService.java
@@ -28,7 +28,7 @@ public class TrainerService {
 	}
 
 	public InvitationCodeVerifyResponse verifyInvitationCode(String invitationCode) {
-		boolean isVerified = trainerRepository.findByInvitationCodeAndDeletedAtIsNull(invitationCode).isPresent();
+		boolean isVerified = trainerRepository.existsByInvitationCodeAndDeletedAtIsNull(invitationCode);
 		String trainerName = isVerified ? getTrainerWithInvitationCode(invitationCode).getMember().getName() : null;
 
 		return new InvitationCodeVerifyResponse(isVerified, trainerName);

--- a/src/main/java/com/tnt/application/trainer/TrainerService.java
+++ b/src/main/java/com/tnt/application/trainer/TrainerService.java
@@ -29,8 +29,9 @@ public class TrainerService {
 
 	public InvitationCodeVerifyResponse verifyInvitationCode(String invitationCode) {
 		boolean isVerified = trainerRepository.findByInvitationCodeAndDeletedAtIsNull(invitationCode).isPresent();
+		String trainerName = isVerified ? getTrainerWithInvitationCode(invitationCode).getMember().getName() : null;
 
-		return new InvitationCodeVerifyResponse(isVerified);
+		return new InvitationCodeVerifyResponse(isVerified, trainerName);
 	}
 
 	@Transactional
@@ -55,5 +56,4 @@ public class TrainerService {
 		return trainerSearchRepository.findByInvitationCode(invitationCode)
 			.orElseThrow(() -> new NotFoundException(TRAINER_NOT_FOUND));
 	}
-
 }

--- a/src/main/java/com/tnt/domain/member/Member.java
+++ b/src/main/java/com/tnt/domain/member/Member.java
@@ -164,9 +164,9 @@ public class Member extends BaseTimeEntity {
 		this.deletedAt = LocalDateTime.now();
 	}
 
-	public String getAge() {
+	public Integer getAge() {
 		if (isNull(this.birthday)) {
-			return "비공개";
+			return null;
 		}
 
 		LocalDate currentDate = LocalDate.now();
@@ -177,6 +177,6 @@ public class Member extends BaseTimeEntity {
 			age--;
 		}
 
-		return String.valueOf(age);
+		return age;
 	}
 }

--- a/src/main/java/com/tnt/dto/trainer/response/ConnectWithTraineeResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/ConnectWithTraineeResponse.java
@@ -16,8 +16,8 @@ public record ConnectWithTraineeResponse(
 	@Schema(description = "트레이니 프로필 이미지 URL", example = "https://images.tntapp.co.kr/3h4f.jpg", nullable = false)
 	String traineeProfileImageUrl,
 
-	@Schema(description = "트레이니 나이", examples = {"20세", "비공개"}, nullable = false)
-	String traineeAge,
+	@Schema(description = "트레이니 나이", example = "25", nullable = true)
+	Integer traineeAge,
 
 	@Schema(description = "트레이니 키", example = "178.6cm", nullable = false)
 	Double height,

--- a/src/main/java/com/tnt/dto/trainer/response/GetCalendarPtLessonCountResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/GetCalendarPtLessonCountResponse.java
@@ -1,0 +1,23 @@
+package com.tnt.dto.trainer.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트레이너 - 달력 스케쥴 개수 표시 응답")
+public record GetCalendarPtLessonCountResponse(
+	@Schema(description = "해당 월의 각 날짜의 PT 수업 개수", nullable = true)
+	List<CalendarPtLessonCount> calendarPtLessonCounts
+) {
+
+	public record CalendarPtLessonCount(
+		@Schema(description = "해당 날짜", example = "2025-01-29", nullable = false)
+		LocalDate date,
+
+		@Schema(description = "해당 날짜의 총 PT 수업 개수", example = "5", nullable = false)
+		Integer count
+	) {
+
+	}
+}

--- a/src/main/java/com/tnt/dto/trainer/response/InvitationCodeVerifyResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/InvitationCodeVerifyResponse.java
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "트레이너 초대 코드 인증 응답")
 public record InvitationCodeVerifyResponse(
 	@Schema(description = "초대 코드 인증 여부", example = "true", nullable = false)
-	boolean isVerified
+	Boolean isVerified,
+
+	@Schema(description = "트레이너 이름", example = "조만제", nullable = true)
+	String trainerName
 ) {
 
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
@@ -53,6 +53,7 @@ public class PtLessonSearchRepository {
 				ptLesson.lessonStart.between(startDate, endDate),
 				ptLesson.deletedAt.isNull()
 			)
+			.orderBy(ptLesson.lessonStart.asc())
 			.fetch();
 	}
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
@@ -7,6 +7,7 @@ import static com.tnt.domain.trainee.QTrainee.trainee;
 import static com.tnt.domain.trainer.QTrainer.trainer;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -36,6 +37,22 @@ public class PtLessonSearchRepository {
 				ptLesson.deletedAt.isNull()
 			)
 			.orderBy(ptLesson.lessonStart.asc())
+			.fetch();
+	}
+
+	public List<PtLesson> findAllByTraineeIdForCalendar(Long traineeId, Integer year, Integer month) {
+		LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
+		LocalDateTime endDate = startDate.plusMonths(1).minusNanos(1);
+
+		return jpaQueryFactory
+			.selectFrom(ptLesson)
+			.join(ptLesson.ptTrainerTrainee, ptTrainerTrainee).fetchJoin()
+			.join(ptTrainerTrainee.trainer, trainer).fetchJoin()
+			.where(
+				trainer.id.eq(traineeId),
+				ptLesson.lessonStart.between(startDate, endDate),
+				ptLesson.deletedAt.isNull()
+			)
 			.fetch();
 	}
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerRepository.java
@@ -11,4 +11,6 @@ public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 	Optional<Trainer> findByMemberIdAndDeletedAtIsNull(Long memberId);
 
 	Optional<Trainer> findByInvitationCodeAndDeletedAtIsNull(String invitationCode);
+
+	boolean existsByInvitationCodeAndDeletedAtIsNull(String invitationCode);
 }

--- a/src/main/java/com/tnt/presentation/trainer/TrainerController.java
+++ b/src/main/java/com/tnt/presentation/trainer/TrainerController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.tnt.application.pt.PtService;
 import com.tnt.application.trainer.TrainerService;
 import com.tnt.dto.trainer.response.ConnectWithTraineeResponse;
+import com.tnt.dto.trainer.response.GetCalendarPtLessonCountResponse;
 import com.tnt.dto.trainer.response.GetPtLessonsOnDateResponse;
 import com.tnt.dto.trainer.response.InvitationCodeResponse;
 import com.tnt.dto.trainer.response.InvitationCodeVerifyResponse;
@@ -59,7 +60,7 @@ public class TrainerController {
 	@ResponseStatus(OK)
 	@GetMapping("/first-connected-trainee")
 	public ConnectWithTraineeResponse getFirstConnectedTrainee(@AuthMember Long memberId,
-		@RequestParam("trainerId") Long trainerId, @RequestParam Long traineeId) {
+		@RequestParam("trainerId") Long trainerId, @RequestParam("traineeId") Long traineeId) {
 		return ptService.getFirstTrainerTraineeConnect(memberId, trainerId, traineeId);
 	}
 
@@ -69,5 +70,13 @@ public class TrainerController {
 	public GetPtLessonsOnDateResponse getPtLessonsOnDate(@AuthMember Long memberId,
 		@PathVariable("date") LocalDate date) {
 		return ptService.getPtLessonsOnDate(memberId, date);
+	}
+
+	@Operation(summary = "달력 스케쥴 개수 표시에 필요한 데이터 요청 API")
+	@ResponseStatus(OK)
+	@GetMapping("/lessons/calendar")
+	public GetCalendarPtLessonCountResponse getCalendarPtLessonCount(@AuthMember Long memberId,
+		@RequestParam("year") Integer year, @RequestParam("month") Integer month) {
+		return ptService.getCalendarPtLessonCount(memberId, year, month);
 	}
 }

--- a/src/main/java/com/tnt/presentation/trainer/TrainerController.java
+++ b/src/main/java/com/tnt/presentation/trainer/TrainerController.java
@@ -23,7 +23,10 @@ import com.tnt.dto.trainer.response.InvitationCodeVerifyResponse;
 import com.tnt.gateway.config.AuthMember;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "트레이너", description = "트레이너 관련 API")
@@ -68,7 +71,7 @@ public class TrainerController {
 	@ResponseStatus(OK)
 	@GetMapping("/lessons/{date}")
 	public GetPtLessonsOnDateResponse getPtLessonsOnDate(@AuthMember Long memberId,
-		@PathVariable("date") LocalDate date) {
+		@Parameter(description = "날짜", example = "2025-01-03") @PathVariable("date") LocalDate date) {
 		return ptService.getPtLessonsOnDate(memberId, date);
 	}
 
@@ -76,7 +79,8 @@ public class TrainerController {
 	@ResponseStatus(OK)
 	@GetMapping("/lessons/calendar")
 	public GetCalendarPtLessonCountResponse getCalendarPtLessonCount(@AuthMember Long memberId,
-		@RequestParam("year") Integer year, @RequestParam("month") Integer month) {
+		@Parameter(description = "년도", example = "2021") @RequestParam("year") @Min(1900) @Max(2100) Integer year,
+		@Parameter(description = "월", example = "3") @RequestParam("month") @Min(1) @Max(12) Integer month) {
 		return ptService.getCalendarPtLessonCount(memberId, year, month);
 	}
 }

--- a/src/test/java/com/tnt/application/member/SignUpServiceTest.java
+++ b/src/test/java/com/tnt/application/member/SignUpServiceTest.java
@@ -6,6 +6,7 @@ import static com.tnt.domain.member.MemberType.TRAINER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -89,7 +90,7 @@ class SignUpServiceTest {
 		given(memberService.saveMember(any(Member.class))).willReturn(traineeMember);
 		given(traineeService.saveTrainee(any(Trainee.class))).willReturn(
 			Trainee.builder().id(1L).member(traineeMember).height(180.0).weight(75.0).build());
-		given(ptGoalService.saveAllPtGoals(any(List.class))).willReturn(Stream.of("목표1", "목표2")
+		given(ptGoalService.saveAllPtGoals(anyList())).willReturn(Stream.of("목표1", "목표2")
 			.map(content -> PtGoal.builder().traineeId(traineeMember.getId()).content(content).build())
 			.toList());
 

--- a/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
+++ b/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
@@ -158,6 +158,8 @@ class TrainerServiceTest {
 
 		given(trainerRepository.findByInvitationCodeAndDeletedAtIsNull(code))
 			.willReturn(java.util.Optional.of(Trainer.builder().member(member).build()));
+		given(trainerSearchRepository.findByInvitationCode(code))
+			.willReturn(java.util.Optional.of(Trainer.builder().member(member).build()));
 
 		// when
 		InvitationCodeVerifyResponse response = trainerService.verifyInvitationCode(code);

--- a/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
+++ b/src/test/java/com/tnt/application/trainer/TrainerServiceTest.java
@@ -156,8 +156,8 @@ class TrainerServiceTest {
 			.memberType(TRAINER)
 			.build();
 
-		given(trainerRepository.findByInvitationCodeAndDeletedAtIsNull(code))
-			.willReturn(java.util.Optional.of(Trainer.builder().member(member).build()));
+		given(trainerRepository.existsByInvitationCodeAndDeletedAtIsNull(code))
+			.willReturn(true);
 		given(trainerSearchRepository.findByInvitationCode(code))
 			.willReturn(java.util.Optional.of(Trainer.builder().member(member).build()));
 


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #42 

**✅ Tasks**

- 트레이너 홈 화면에서 달력 표시에 필요한 각 날짜별 수업 개수를 리턴하는 API를 구현
- @SeonJeongk 의 요청으로 트레이너 초대 코드 인증 성공시 트레이너의 이름도 반환하도록 response를 수정

**🙋🏻 More**
![image](https://github.com/user-attachments/assets/eddf3369-d46a-4c1e-8936-cb8facd0256e)

Gradle 8.5 에서 테스트 프레임워크의 자동 로딩 기능이 더 이상 권장되지 않으며, Gradle 9.0에서 제거될 예정으로 명시적으로 `testRuntimeOnly 'org.junit.platform:junit-platform-launcher'`를 넣어주어야함

https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_suites
<img width="703" alt="image" src="https://github.com/user-attachments/assets/5d47febe-84e8-4821-aefe-fe78970c2a5e" />

