### PR TITLE
[TNT-228] feat: 트레이니 홈 화면 달력 - PT 수업 있는 날짜 반환 API 구현

### DIFF
--- a/src/main/java/com/tnt/dto/trainee/response/ConnectWithTrainerResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/ConnectWithTrainerResponse.java
@@ -1,4 +1,4 @@
-package com.tnt.dto.trainer.response;
+package com.tnt.dto.trainee.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/tnt/dto/trainee/response/GetTraineeCalendarPtLessonCountResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetTraineeCalendarPtLessonCountResponse.java
@@ -1,0 +1,14 @@
+package com.tnt.dto.trainee.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트레이니 달력 PT 수업 있는 날짜 조회 응답")
+public record GetTraineeCalendarPtLessonCountResponse(
+	@Schema(description = "PT 수업 있는 날짜 목록", examples = {"2025-01-01", "2025-01-13"}, nullable = true)
+	List<LocalDate> ptLessonDates
+) {
+
+}

--- a/src/main/java/com/tnt/dto/trainer/ConnectWithTrainerDto.java
+++ b/src/main/java/com/tnt/dto/trainer/ConnectWithTrainerDto.java
@@ -1,6 +1,6 @@
 package com.tnt.dto.trainer;
 
-import com.tnt.dto.trainer.response.ConnectWithTrainerResponse;
+import com.tnt.dto.trainee.response.ConnectWithTrainerResponse;
 
 public record ConnectWithTrainerDto(
 	String trainerFcmToken,

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonSearchRepository.java
@@ -41,7 +41,7 @@ public class PtLessonSearchRepository {
 			.fetch();
 	}
 
-	public List<PtLesson> findAllByTraineeIdForCalendar(Long traineeId, Integer year, Integer month) {
+	public List<PtLesson> findAllByTraineeIdForTrainerCalendar(Long traineeId, Integer year, Integer month) {
 		LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
 		LocalDateTime endDate = startDate.plusMonths(1).minusNanos(1);
 
@@ -52,6 +52,20 @@ public class PtLessonSearchRepository {
 			.where(
 				trainer.id.eq(traineeId),
 				ptLesson.lessonStart.between(startDate, endDate),
+				ptLesson.deletedAt.isNull()
+			)
+			.orderBy(ptLesson.lessonStart.asc())
+			.fetch();
+	}
+
+	public List<PtLesson> findAllByTraineeIdForTraineeCalendar(Long traineeId, LocalDate startDate, LocalDate endDate) {
+		return jpaQueryFactory
+			.selectFrom(ptLesson)
+			.join(ptLesson.ptTrainerTrainee, ptTrainerTrainee).fetchJoin()
+			.join(ptTrainerTrainee.trainee, trainee).fetchJoin()
+			.where(
+				trainee.id.eq(traineeId),
+				ptLesson.lessonStart.between(startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)),
 				ptLesson.deletedAt.isNull()
 			)
 			.orderBy(ptLesson.lessonStart.asc())

--- a/src/main/java/com/tnt/presentation/trainee/TraineeController.java
+++ b/src/main/java/com/tnt/presentation/trainee/TraineeController.java
@@ -2,11 +2,16 @@ package com.tnt.presentation.trainee;
 
 import static com.tnt.common.constant.ImageConstant.DIET_S3_IMAGE_PATH;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
+import java.time.LocalDate;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +22,13 @@ import com.tnt.application.pt.PtService;
 import com.tnt.application.s3.S3Service;
 import com.tnt.dto.trainee.request.ConnectWithTrainerRequest;
 import com.tnt.dto.trainee.request.CreateDietRequest;
+import com.tnt.dto.trainee.response.ConnectWithTrainerResponse;
+import com.tnt.dto.trainee.response.GetTraineeCalendarPtLessonCountResponse;
 import com.tnt.dto.trainer.ConnectWithTrainerDto;
-import com.tnt.dto.trainer.response.ConnectWithTrainerResponse;
 import com.tnt.gateway.config.AuthMember;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -56,5 +63,16 @@ public class TraineeController {
 		String dietImageUrl = s3Service.uploadImage(null, DIET_S3_IMAGE_PATH, dietImage);
 
 		ptService.createDiet(memberId, request, dietImageUrl);
+	}
+
+	@Operation(summary = "달력 PT 수업 있는 날 표시 데이터 조회 API")
+	@ResponseStatus(OK)
+	@GetMapping("/lessons/calendar")
+	public GetTraineeCalendarPtLessonCountResponse getTraineeCalendarPtLessonCount(@AuthMember Long memberId,
+		@Parameter(description = "조회 시작 날짜", example = "2025-01-10")
+		@RequestParam("startDate") LocalDate startDate,
+		@Parameter(description = "조회 종료 날짜", example = "2025-02-15")
+		@RequestParam("endDate") LocalDate endDate) {
+		return ptService.getTraineeCalendarPtLessonCount(memberId, startDate, endDate);
 	}
 }

--- a/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
+++ b/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
@@ -107,7 +107,7 @@ class WithdrawServiceTest {
 
 		PtTrainerTrainee ptTrainerTrainee = PtTrainerTraineeFixture.getPtTrainerTrainee1(trainer, trainee);
 
-		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons(ptTrainerTrainee);
+		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons1WithId(ptTrainerTrainee);
 
 		given(memberService.getMemberWithMemberId(trainerMember.getId())).willReturn(trainerMember);
 		given(trainerService.getTrainerWithMemberId(trainerMember.getId())).willReturn(trainer);
@@ -136,7 +136,7 @@ class WithdrawServiceTest {
 
 		List<PtGoal> ptGoals = List.of(PtGoal.builder().id(1L).traineeId(trainee.getId()).content("test").build());
 
-		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons(ptTrainerTrainee);
+		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons1WithId(ptTrainerTrainee);
 
 		given(memberService.getMemberWithMemberId(traineeMember.getId())).willReturn(traineeMember);
 		given(traineeService.getTraineeWithMemberId(traineeMember.getId())).willReturn(trainee);

--- a/src/test/java/com/tnt/application/pt/PtServiceTest.java
+++ b/src/test/java/com/tnt/application/pt/PtServiceTest.java
@@ -255,7 +255,7 @@ class PtServiceTest {
 
 		PtTrainerTrainee ptTrainerTrainee = PtTrainerTraineeFixture.getPtTrainerTrainee1(trainer, trainee);
 
-		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons(ptTrainerTrainee);
+		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons1WithId(ptTrainerTrainee);
 
 		given(ptLessonRepository.findAllByPtTrainerTraineeAndDeletedAtIsNull(ptTrainerTrainee)).willReturn(ptLessons);
 
@@ -302,7 +302,7 @@ class PtServiceTest {
 				.build());
 
 		given(trainerService.getTrainerWithMemberId(trainer.getId())).willReturn(trainer);
-		given(ptLessonSearchRepository.findAllByTraineeIdForCalendar(trainer.getId(), year, month))
+		given(ptLessonSearchRepository.findAllByTraineeIdForTrainerCalendar(trainer.getId(), year, month))
 			.willReturn(ptLessons);
 
 		// when

--- a/src/test/java/com/tnt/fixture/PtLessonsFixture.java
+++ b/src/test/java/com/tnt/fixture/PtLessonsFixture.java
@@ -8,7 +8,7 @@ import com.tnt.domain.pt.PtTrainerTrainee;
 
 public class PtLessonsFixture {
 
-	public static List<PtLesson> getPtLessons(PtTrainerTrainee ptTrainerTrainee) {
+	public static List<PtLesson> getPtLessons1WithId(PtTrainerTrainee ptTrainerTrainee) {
 		return List.of(PtLesson.builder()
 			.id(1L)
 			.ptTrainerTrainee(ptTrainerTrainee)

--- a/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
@@ -4,9 +4,11 @@ import static com.tnt.domain.trainee.DietType.DINNER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
@@ -31,15 +33,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tnt.domain.member.Member;
+import com.tnt.domain.pt.PtLesson;
+import com.tnt.domain.pt.PtTrainerTrainee;
 import com.tnt.domain.trainee.Trainee;
 import com.tnt.domain.trainer.Trainer;
 import com.tnt.dto.trainee.request.ConnectWithTrainerRequest;
 import com.tnt.dto.trainee.request.CreateDietRequest;
 import com.tnt.fixture.MemberFixture;
+import com.tnt.fixture.PtTrainerTraineeFixture;
 import com.tnt.fixture.TraineeFixture;
 import com.tnt.fixture.TrainerFixture;
 import com.tnt.gateway.filter.CustomUserDetails;
 import com.tnt.infrastructure.mysql.repository.member.MemberRepository;
+import com.tnt.infrastructure.mysql.repository.pt.PtLessonRepository;
+import com.tnt.infrastructure.mysql.repository.pt.PtTrainerTraineeRepository;
 import com.tnt.infrastructure.mysql.repository.trainee.TraineeRepository;
 import com.tnt.infrastructure.mysql.repository.trainer.TrainerRepository;
 
@@ -64,6 +71,10 @@ class TraineeControllerTest {
 
 	@Autowired
 	private TraineeRepository traineeRepository;
+	@Autowired
+	private PtTrainerTraineeRepository ptTrainerTraineeRepository;
+	@Autowired
+	private PtLessonRepository ptLessonRepository;
 
 	@AfterEach
 	void tearDown() {
@@ -197,6 +208,81 @@ class TraineeControllerTest {
 
 		// then
 		result.andExpect(status().isCreated())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 트레이니 홈 달력 PT 수업 있는 날 표시 데이터 조회 성공")
+	void get_trainee_calendar_pt_lesson_count_success() throws Exception {
+		// given
+		Member trainerMember = MemberFixture.getTrainerMember1();
+		Member traineeMember = MemberFixture.getTraineeMember2();
+
+		trainerMember = memberRepository.save(trainerMember);
+		traineeMember = memberRepository.save(traineeMember);
+
+		CustomUserDetails traineeUserDetails = new CustomUserDetails(traineeMember.getId(),
+			traineeMember.getId().toString(),
+			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(traineeUserDetails, null,
+			authoritiesMapper.mapAuthorities(traineeUserDetails.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Trainer trainer = TrainerFixture.getTrainer2(trainerMember);
+		Trainee trainee = TraineeFixture.getTrainee1(traineeMember);
+
+		trainer = trainerRepository.save(trainer);
+		trainee = traineeRepository.save(trainee);
+
+		PtTrainerTrainee ptTrainerTrainee = PtTrainerTraineeFixture.getPtTrainerTrainee1(trainer, trainee);
+
+		ptTrainerTrainee = ptTrainerTraineeRepository.save(ptTrainerTrainee);
+
+		LocalDateTime date1 = LocalDateTime.of(2025, 1, 3, 10, 0);
+		LocalDateTime date2 = LocalDateTime.of(2025, 1, 5, 13, 20);
+		LocalDateTime date3 = LocalDateTime.of(2025, 1, 7, 20, 0);
+		LocalDateTime date4 = LocalDateTime.of(2025, 1, 10, 17, 30);
+
+		List<PtLesson> ptLessons = List.of(PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(date1)
+				.lessonEnd(date1.plusHours(1))
+				.build(),
+			PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(date2)
+				.lessonEnd(date2.plusHours(1))
+				.build(),
+			PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(date3)
+				.lessonEnd(date3.plusHours(1))
+				.build(),
+			PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(date4)
+				.lessonEnd(date4.plusHours(1))
+				.build());
+
+		ptLessonRepository.saveAll(ptLessons);
+
+		LocalDate startDate = LocalDate.of(2024, 12, 1);
+		LocalDate endDate = LocalDate.of(2025, 2, 28);
+
+		// when & then
+		mockMvc.perform(get("/trainees/lessons/calendar")
+				.param("startDate", startDate.toString())
+				.param("endDate", endDate.toString())
+				.contentType("application/json"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.ptLessonDates").isArray())
+			.andExpect(jsonPath("$.ptLessonDates.size()").value(4))
+			.andExpect(jsonPath("$.ptLessonDates[0]").value("2025-01-03"))
+			.andExpect(jsonPath("$.ptLessonDates[1]").value("2025-01-05"))
+			.andExpect(jsonPath("$.ptLessonDates[2]").value("2025-01-07"))
+			.andExpect(jsonPath("$.ptLessonDates[3]").value("2025-01-10"))
 			.andDo(print());
 	}
 }


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #56 

**✅ Tasks**

- Query parameter를 통해 해당 기간 동안 트레이니의 홈 화면에 있는 달력에 PT 수업이 있는 날짜들을 반환하는 API를 구현했습니다.

**🙋🏻 More**

- Test code의 Fixture를 정의할때는 xxx1WithId, xxx1 로 ID를 직접 정해주거나 아니면 `@TSID`에 위임하는 형식으로 나누어 주세요! 통합 테스트에서 직접 ID를 지정해주면 에러가 발생합니다.