### PR TITLE
[TNT-218] feat: 트레이니 특정 식단, 홈 기록 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/tnt/application/member/MemberService.java
+++ b/src/main/java/com/tnt/application/member/MemberService.java
@@ -79,12 +79,10 @@ public class MemberService {
 			Trainee trainee = traineeService.getTraineeWithMemberId(memberId);
 			List<String> ptGoals = ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId()).stream().map(
 				PtGoal::getContent).toList();
-			PtTrainerTrainee ptTrainerTrainee = ptService.getPtTrainerTraineeWithTraineeId(trainee.getId());
-			Trainer trainer = trainerService.getTrainerWithMemberId(ptTrainerTrainee.getTrainer().getMember().getId());
+			boolean isConnected = ptService.isPtTrainerTraineeExistWithTraineeId(trainee.getId());
 
-			TraineeInfo traineeInfo = new TraineeInfo(trainer.getId(), trainer.getInvitationCode(),
-				member.getBirthday(), member.getAge(), trainee.getHeight(), trainee.getWeight(),
-				trainee.getCautionNote(), ptGoals);
+			TraineeInfo traineeInfo = new TraineeInfo(isConnected, member.getBirthday(),
+				member.getAge(), trainee.getHeight(), trainee.getWeight(), trainee.getCautionNote(), ptGoals);
 
 			memberInfo = new GetMemberInfoResponse(member.getName(), member.getEmail(), member.getProfileImageUrl(),
 				member.getMemberType(), member.getSocialType(), null, traineeInfo);

--- a/src/main/java/com/tnt/application/member/MemberService.java
+++ b/src/main/java/com/tnt/application/member/MemberService.java
@@ -79,9 +79,12 @@ public class MemberService {
 			Trainee trainee = traineeService.getTraineeWithMemberId(memberId);
 			List<String> ptGoals = ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId()).stream().map(
 				PtGoal::getContent).toList();
+			PtTrainerTrainee ptTrainerTrainee = ptService.getPtTrainerTraineeWithTraineeId(trainee.getId());
+			Trainer trainer = trainerService.getTrainerWithMemberId(ptTrainerTrainee.getTrainer().getMember().getId());
 
-			TraineeInfo traineeInfo = new TraineeInfo(member.getBirthday(),
-				member.getAge(), trainee.getHeight(), trainee.getWeight(), trainee.getCautionNote(), ptGoals);
+			TraineeInfo traineeInfo = new TraineeInfo(trainer.getId(), trainer.getInvitationCode(),
+				member.getBirthday(), member.getAge(), trainee.getHeight(), trainee.getWeight(),
+				trainee.getCautionNote(), ptGoals);
 
 			memberInfo = new GetMemberInfoResponse(member.getName(), member.getEmail(), member.getProfileImageUrl(),
 				member.getMemberType(), member.getSocialType(), null, traineeInfo);

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -31,6 +31,8 @@ import com.tnt.domain.trainee.Trainee;
 import com.tnt.domain.trainer.Trainer;
 import com.tnt.dto.trainee.request.ConnectWithTrainerRequest;
 import com.tnt.dto.trainee.request.CreateDietRequest;
+import com.tnt.dto.trainee.response.CreateDietResponse;
+import com.tnt.dto.trainee.response.GetDietResponse;
 import com.tnt.dto.trainee.response.GetTraineeCalendarPtLessonCountResponse;
 import com.tnt.dto.trainer.ConnectWithTrainerDto;
 import com.tnt.dto.trainer.request.CreatePtLessonRequest;
@@ -201,7 +203,7 @@ public class PtService {
 	}
 
 	@Transactional
-	public void createDiet(Long memberId, CreateDietRequest request, String dietImageUrl) {
+	public CreateDietResponse createDiet(Long memberId, CreateDietRequest request, String dietImageUrl) {
 		Trainee trainee = traineeService.getTraineeWithMemberId(memberId);
 
 		Diet diet = Diet.builder()
@@ -212,7 +214,20 @@ public class PtService {
 			.dietType(request.dietType())
 			.build();
 
-		dietService.save(diet);
+		Diet saveDiet = dietService.save(diet);
+
+		return new CreateDietResponse(saveDiet.getId(), saveDiet.getDate(), saveDiet.getDietImageUrl(),
+			saveDiet.getDietType(), saveDiet.getMemo());
+	}
+
+	@Transactional(readOnly = true)
+	public GetDietResponse getDiet(Long memberId, Long dietId) {
+		Trainee trainee = traineeService.getTraineeWithMemberId(memberId);
+
+		Diet diet = dietService.getDietWithTraineeIdAndDietId(dietId, trainee.getId());
+
+		return new GetDietResponse(diet.getId(), diet.getDate(), diet.getDietImageUrl(), diet.getDietType(),
+			diet.getMemo());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/tnt/application/trainee/DietService.java
+++ b/src/main/java/com/tnt/application/trainee/DietService.java
@@ -2,12 +2,15 @@ package com.tnt.application.trainee;
 
 import static com.tnt.common.error.model.ErrorMessage.DIET_NOT_FOUND;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.trainee.Diet;
 import com.tnt.infrastructure.mysql.repository.trainee.DietRepository;
+import com.tnt.infrastructure.mysql.repository.trainee.DietSearchRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class DietService {
 
 	private final DietRepository dietRepository;
+	private final DietSearchRepository dietSearchRepository;
 
 	@Transactional
 	public Diet save(Diet diet) {
@@ -25,5 +29,9 @@ public class DietService {
 	public Diet getDietWithTraineeIdAndDietId(Long dietId, Long traineeId) {
 		return dietRepository.findByIdAndTraineeIdAndDeletedAtIsNull(dietId, traineeId)
 			.orElseThrow(() -> new NotFoundException(DIET_NOT_FOUND));
+	}
+
+	public List<Diet> getDietsWithTraineeIdForHome(Long traineeId, Integer year, Integer month) {
+		return dietSearchRepository.findAllByTraineeIdForHome(traineeId, year, month);
 	}
 }

--- a/src/main/java/com/tnt/application/trainee/DietService.java
+++ b/src/main/java/com/tnt/application/trainee/DietService.java
@@ -1,8 +1,11 @@
 package com.tnt.application.trainee;
 
+import static com.tnt.common.error.model.ErrorMessage.DIET_NOT_FOUND;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.trainee.Diet;
 import com.tnt.infrastructure.mysql.repository.trainee.DietRepository;
 
@@ -17,5 +20,10 @@ public class DietService {
 	@Transactional
 	public Diet save(Diet diet) {
 		return dietRepository.save(diet);
+	}
+
+	public Diet getDietWithTraineeIdAndDietId(Long dietId, Long traineeId) {
+		return dietRepository.findByIdAndTraineeIdAndDeletedAtIsNull(dietId, traineeId)
+			.orElseThrow(() -> new NotFoundException(DIET_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/tnt/application/trainee/DietService.java
+++ b/src/main/java/com/tnt/application/trainee/DietService.java
@@ -31,7 +31,7 @@ public class DietService {
 			.orElseThrow(() -> new NotFoundException(DIET_NOT_FOUND));
 	}
 
-	public List<Diet> getDietsWithTraineeIdForHome(Long traineeId, Integer year, Integer month) {
-		return dietSearchRepository.findAllByTraineeIdForHome(traineeId, year, month);
+	public List<Diet> getDietsWithTraineeIdForDaily(Long traineeId, Integer year, Integer month) {
+		return dietSearchRepository.findAllByTraineeIdForDaily(traineeId, year, month);
 	}
 }

--- a/src/main/java/com/tnt/application/trainee/TraineeService.java
+++ b/src/main/java/com/tnt/application/trainee/TraineeService.java
@@ -29,9 +29,13 @@ public class TraineeService {
 			.orElseThrow(() -> new NotFoundException(TRAINEE_NOT_FOUND));
 	}
 
+	public Trainee getTraineeWithMemberIdNoFetch(Long memberId) {
+		return traineeRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+			.orElseThrow(() -> new NotFoundException(TRAINEE_NOT_FOUND));
+	}
+
 	public Trainee getTraineeWithId(Long traineeId) {
 		return traineeSearchRepository.findById(traineeId)
 			.orElseThrow(() -> new NotFoundException(TRAINEE_NOT_FOUND));
 	}
-
 }

--- a/src/main/java/com/tnt/common/error/model/ErrorMessage.java
+++ b/src/main/java/com/tnt/common/error/model/ErrorMessage.java
@@ -82,7 +82,8 @@ public enum ErrorMessage {
 	DIET_NULL_TRAINEE_ID("식단 트레이니 id가 null 입니다."),
 	DIET_INVALID_IMAGE_URL("유효하지 않는 식단 사진입니다."),
 	DIET_INVALID_MEMO("식단 메모가 올바르지 않습니다."),
-	UNSUPPORTED_DIET_TYPE("지원하지 않는 식단 타입입니다.");
+	UNSUPPORTED_DIET_TYPE("지원하지 않는 식단 타입입니다."),
+	DIET_NOT_FOUND("존재하지 않는 식단입니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/tnt/common/error/model/ErrorMessage.java
+++ b/src/main/java/com/tnt/common/error/model/ErrorMessage.java
@@ -78,6 +78,7 @@ public enum ErrorMessage {
 	PT_LESSON_INVALID_MEMO("수업 메모의 길이는 공백 포함 30자 이하이어야 합니다."),
 	PT_LESSON_DUPLICATE_TIME("이미 예약된 시간대입니다."),
 	PT_LESSON_NOT_FOUND("존재하지 않는 수업입니다."),
+	PT_LESSON_OVERFLOW("총 수업 수 보다 수업을 더 추가 할 수 없습니다."),
 
 	DIET_NULL_TRAINEE_ID("식단 트레이니 id가 null 입니다."),
 	DIET_INVALID_IMAGE_URL("유효하지 않는 식단 사진입니다."),

--- a/src/main/java/com/tnt/domain/pt/PtLesson.java
+++ b/src/main/java/com/tnt/domain/pt/PtLesson.java
@@ -54,22 +54,34 @@ public class PtLesson extends BaseTimeEntity {
 	@Column(name = "memo", nullable = true, length = MEMO_LENGTH)
 	private String memo;
 
+	@Column(name = "session", nullable = false)
+	private Integer session;
+
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
 
 	@Builder
 	public PtLesson(Long id, PtTrainerTrainee ptTrainerTrainee, LocalDateTime lessonStart, LocalDateTime lessonEnd,
-		@Nullable String memo) {
+		@Nullable String memo, Integer session) {
 		this.id = id;
 		this.ptTrainerTrainee = requireNonNull(ptTrainerTrainee, PT_TRAINER_TRAINEE_NULL.getMessage());
 		this.lessonStart = requireNonNull(lessonStart);
 		this.lessonEnd = requireNonNull(lessonEnd);
 		this.isCompleted = false;
+		this.session = requireNonNull(session);
 		validateAndSetMemo(memo);
 	}
 
 	public void completeLesson() {
 		this.isCompleted = true;
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public void increaseSession() {
+		this.session++;
 	}
 
 	private void validateAndSetMemo(String memo) {
@@ -82,9 +94,5 @@ public class PtLesson extends BaseTimeEntity {
 		}
 
 		this.memo = memo;
-	}
-
-	public void softDelete() {
-		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/tnt/domain/trainee/Diet.java
+++ b/src/main/java/com/tnt/domain/trainee/Diet.java
@@ -9,12 +9,11 @@ import java.time.LocalDateTime;
 
 import com.tnt.infrastructure.mysql.BaseTimeEntity;
 
+import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -33,7 +32,7 @@ public class Diet extends BaseTimeEntity {
 	public static final int DIET_TYPE_LENGTH = 20;
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Tsid
 	@Column(name = "id", nullable = false, unique = true)
 	private Long id;
 

--- a/src/main/java/com/tnt/domain/trainee/Trainee.java
+++ b/src/main/java/com/tnt/domain/trainee/Trainee.java
@@ -1,9 +1,7 @@
 package com.tnt.domain.trainee;
 
 import static com.tnt.common.error.model.ErrorMessage.TRAINEE_INVALID_CAUTION_NOTE;
-import static com.tnt.common.error.model.ErrorMessage.TRAINEE_NULL_HEIGHT;
 import static com.tnt.common.error.model.ErrorMessage.TRAINEE_NULL_MEMBER;
-import static com.tnt.common.error.model.ErrorMessage.TRAINEE_NULL_WEIGHT;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
@@ -46,10 +44,10 @@ public class Trainee extends BaseTimeEntity {
 	@JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(NO_CONSTRAINT))
 	private Member member;
 
-	@Column(name = "height", nullable = false)
+	@Column(name = "height", nullable = true)
 	private Double height;
 
-	@Column(name = "weight", nullable = false)
+	@Column(name = "weight", nullable = true)
 	private Double weight;
 
 	@Column(name = "caution_note", nullable = true, length = CAUTION_NOTE_LENGTH)
@@ -62,8 +60,8 @@ public class Trainee extends BaseTimeEntity {
 	public Trainee(Long id, Member member, Double height, Double weight, @Nullable String cautionNote) {
 		this.id = id;
 		this.member = requireNonNull(member, TRAINEE_NULL_MEMBER.getMessage());
-		this.height = requireNonNull(height, TRAINEE_NULL_HEIGHT.getMessage());
-		this.weight = requireNonNull(weight, TRAINEE_NULL_WEIGHT.getMessage());
+		this.height = height;
+		this.weight = weight;
 		validateAndSetCautionNote(cautionNote);
 	}
 

--- a/src/main/java/com/tnt/dto/member/MemberProjection.java
+++ b/src/main/java/com/tnt/dto/member/MemberProjection.java
@@ -1,11 +1,7 @@
 package com.tnt.dto.member;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import com.querydsl.core.annotations.QueryProjection;
 import com.tnt.domain.member.MemberType;
-import com.tnt.domain.member.SocialType;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -15,26 +11,6 @@ public class MemberProjection {
 
 	@QueryProjection
 	public record MemberTypeDto(MemberType memberType) {
-
-	}
-
-	@QueryProjection
-	public record MemberInfoDto(
-		String name,
-		String email,
-		String profileImageUrl,
-		LocalDate birthday,
-		MemberType memberType,
-		SocialType socialType,
-		Integer activeTraineeCount,
-		Integer totalTraineeCount,
-		String invitationCode,
-		Long trainerId,
-		Double height,
-		Double weight,
-		String cautionNote,
-		List<String> goalContents
-	) {
 
 	}
 }

--- a/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
@@ -43,11 +43,8 @@ public record GetMemberInfoResponse(
 	}
 
 	public record TraineeInfo(
-		@Schema(description = "트레이너 ID", example = "12352", nullable = true)
-		Long trainerId,
-
-		@Schema(description = "트레이너 초대 코드", example = "2H9DG4X3", nullable = true)
-		String invitationCode,
+		@Schema(description = "트레이너 연결 여부", example = "true", nullable = false)
+		Boolean isConnected,
 
 		@Schema(description = "생년월일", example = "2025-01-01", nullable = true)
 		LocalDate birthday,

--- a/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/tnt/dto/member/response/GetMemberInfoResponse.java
@@ -43,6 +43,12 @@ public record GetMemberInfoResponse(
 	}
 
 	public record TraineeInfo(
+		@Schema(description = "트레이너 ID", example = "12352", nullable = true)
+		Long trainerId,
+
+		@Schema(description = "트레이너 초대 코드", example = "2H9DG4X3", nullable = true)
+		String invitationCode,
+
 		@Schema(description = "생년월일", example = "2025-01-01", nullable = true)
 		LocalDate birthday,
 

--- a/src/main/java/com/tnt/dto/trainee/TraineeProjection.java
+++ b/src/main/java/com/tnt/dto/trainee/TraineeProjection.java
@@ -13,16 +13,9 @@ public class TraineeProjection {
 	@QueryProjection
 	public record PtInfoDto(
 		String trainerName,
+		Integer session,
 		LocalDateTime lessonStart,
 		LocalDateTime lessonEnd
-	) {
-
-	}
-
-	@QueryProjection
-	public record PtCountInfoDto(
-		Integer finishedPtCount,
-		Integer totalPtCount
 	) {
 
 	}

--- a/src/main/java/com/tnt/dto/trainee/TraineeProjection.java
+++ b/src/main/java/com/tnt/dto/trainee/TraineeProjection.java
@@ -1,0 +1,29 @@
+package com.tnt.dto.trainee;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TraineeProjection {
+
+	@QueryProjection
+	public record PtInfoDto(
+		String trainerName,
+		LocalDateTime lessonStart,
+		LocalDateTime lessonEnd
+	) {
+
+	}
+
+	@QueryProjection
+	public record PtCountInfoDto(
+		Integer finishedPtCount,
+		Integer totalPtCount
+	) {
+
+	}
+}

--- a/src/main/java/com/tnt/dto/trainee/response/CreateDietResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/CreateDietResponse.java
@@ -1,0 +1,27 @@
+package com.tnt.dto.trainee.response;
+
+import java.time.LocalDateTime;
+
+import com.tnt.domain.trainee.DietType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트레이니 식단 등록 응답")
+public record CreateDietResponse(
+	@Schema(description = "식단 ID", example = "54924", nullable = false)
+	Long dietId,
+
+	@Schema(description = "식사 날짜", example = "2025-01-01T11:00:00", nullable = false)
+	LocalDateTime date,
+
+	@Schema(description = "식단 사진", example = "https://images.tntapp.co.kr/a3hf2.jpg", nullable = true)
+	String dietImageUrl,
+
+	@Schema(description = "식단 타입", example = "BREAKFAST", nullable = false)
+	DietType dietType,
+
+	@Schema(description = "메모", example = "아 배부르다.", nullable = false)
+	String memo
+) {
+
+}

--- a/src/main/java/com/tnt/dto/trainee/response/GetDietResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetDietResponse.java
@@ -6,7 +6,7 @@ import com.tnt.domain.trainee.DietType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema
+@Schema(description = "트레이니 특정 식단 조회 응답")
 public record GetDietResponse(
 	@Schema(description = "식단 ID", example = "54924", nullable = false)
 	Long dietId,

--- a/src/main/java/com/tnt/dto/trainee/response/GetDietResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetDietResponse.java
@@ -1,0 +1,27 @@
+package com.tnt.dto.trainee.response;
+
+import java.time.LocalDateTime;
+
+import com.tnt.domain.trainee.DietType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema
+public record GetDietResponse(
+	@Schema(description = "식단 ID", example = "54924", nullable = false)
+	Long dietId,
+
+	@Schema(description = "식사 날짜", example = "2025-01-01T11:00:00", nullable = false)
+	LocalDateTime date,
+
+	@Schema(description = "식단 사진", example = "https://images.tntapp.co.kr/a3hf2.jpg", nullable = true)
+	String dietImageUrl,
+
+	@Schema(description = "식단 타입", example = "BREAKFAST", nullable = false)
+	DietType dietType,
+
+	@Schema(description = "메모", example = "아 배부르다.", nullable = false)
+	String memo
+) {
+
+}

--- a/src/main/java/com/tnt/dto/trainee/response/GetTraineeDailyRecordsResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetTraineeDailyRecordsResponse.java
@@ -9,7 +9,7 @@ import com.tnt.domain.trainee.DietType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "트레이니 홈 기록 리스트 조회 응답")
-public record GetTraineeHomeRecordsResponse(
+public record GetTraineeDailyRecordsResponse(
 
 	@Schema(description = "홈 기록 리스트", nullable = false)
 	List<DailyRecord> dailyRecords
@@ -19,7 +19,8 @@ public record GetTraineeHomeRecordsResponse(
 		@Schema(description = "날짜", example = "2025-02-01", nullable = false)
 		LocalDate date,
 
-		List<PtInfo> ptInfos,
+		@Schema(description = "PT 정보", nullable = true)
+		PtInfo ptInfo,
 
 		@Schema(description = "식단 목록", nullable = false)
 		List<DietRecord> diets
@@ -30,7 +31,7 @@ public record GetTraineeHomeRecordsResponse(
 			String trainerName,
 
 			@Schema(description = "PT 회차", example = "8", nullable = false)
-			Integer ptCount,
+			Integer session,
 
 			@Schema(description = "PT 시작 시간", example = "2025-02-01T17:00:00", nullable = false)
 			LocalDateTime lessonStart,

--- a/src/main/java/com/tnt/dto/trainee/response/GetTraineeHomeRecordsResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetTraineeHomeRecordsResponse.java
@@ -12,16 +12,34 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record GetTraineeHomeRecordsResponse(
 
 	@Schema(description = "홈 기록 리스트", nullable = false)
-	List<DailyRecord> homeRecords
+	List<DailyRecord> dailyRecords
 ) {
 
 	public record DailyRecord(
 		@Schema(description = "날짜", example = "2025-02-01", nullable = false)
 		LocalDate date,
 
+		List<PtInfo> ptInfos,
+
 		@Schema(description = "식단 목록", nullable = false)
 		List<DietRecord> diets
 	) {
+
+		public record PtInfo(
+			@Schema(description = "트레이너 이름", example = "홍길동", nullable = false)
+			String trainerName,
+
+			@Schema(description = "PT 회차", example = "8", nullable = false)
+			Integer ptCount,
+
+			@Schema(description = "PT 시작 시간", example = "2025-02-01T17:00:00", nullable = false)
+			LocalDateTime lessonStart,
+
+			@Schema(description = "PT 종료 시간", example = "2025-02-01T18:30:00", nullable = false)
+			LocalDateTime lessonEnd
+		) {
+
+		}
 
 		public record DietRecord(
 			@Schema(description = "식단 ID", example = "54924", nullable = false)

--- a/src/main/java/com/tnt/dto/trainee/response/GetTraineeHomeRecordsResponse.java
+++ b/src/main/java/com/tnt/dto/trainee/response/GetTraineeHomeRecordsResponse.java
@@ -1,0 +1,46 @@
+package com.tnt.dto.trainee.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.tnt.domain.trainee.DietType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트레이니 홈 기록 리스트 조회 응답")
+public record GetTraineeHomeRecordsResponse(
+
+	@Schema(description = "홈 기록 리스트", nullable = false)
+	List<DailyRecord> homeRecords
+) {
+
+	public record DailyRecord(
+		@Schema(description = "날짜", example = "2025-02-01", nullable = false)
+		LocalDate date,
+
+		@Schema(description = "식단 목록", nullable = false)
+		List<DietRecord> diets
+	) {
+
+		public record DietRecord(
+			@Schema(description = "식단 ID", example = "54924", nullable = false)
+			Long dietId,
+
+			@Schema(description = "식사 날짜", example = "2025-01-01T11:00:00", nullable = false)
+			LocalDateTime date,
+
+			@Schema(description = "식단 사진", example = "https://images.tntapp.co.kr/a3hf2.jpg", nullable = true)
+			String dietImageUrl,
+
+			@Schema(description = "식단 타입", example = "BREAKFAST", nullable = false)
+			DietType dietType,
+
+			@Schema(description = "메모", example = "아 배부르다.", nullable = false)
+			String memo
+		) {
+
+		}
+
+	}
+}

--- a/src/main/java/com/tnt/dto/trainer/response/GetActiveTraineesResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/GetActiveTraineesResponse.java
@@ -10,10 +10,10 @@ public record GetActiveTraineesResponse(
 	Integer traineeCount,
 
 	@Schema(description = "트레이니 목록", nullable = false)
-	List<TraineeInfo> trainees
+	List<ActiveTraineeInfo> trainees
 ) {
 
-	public record TraineeInfo(
+	public record ActiveTraineeInfo(
 		@Schema(description = "트레이니 ID", example = "123523564", nullable = false)
 		Long id,
 

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtLessonRepository.java
@@ -13,4 +13,8 @@ public interface PtLessonRepository extends JpaRepository<PtLesson, Long> {
 	List<PtLesson> findAllByPtTrainerTraineeAndDeletedAtIsNull(PtTrainerTrainee ptTrainerTrainee);
 
 	Optional<PtLesson> findByIdAndDeletedAtIsNull(Long id);
+
+	Long countByPtTrainerTraineeAndIsCompletedIsFalseAndDeletedAtIsNull(PtTrainerTrainee ptTrainerTrainee);
+
+	List<PtLesson> findAllByPtTrainerTraineeAndIsCompletedIsFalseAndDeletedAtIsNull(PtTrainerTrainee ptTrainerTrainee);
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtTrainerTraineeSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/pt/PtTrainerTraineeSearchRepository.java
@@ -29,7 +29,10 @@ public class PtTrainerTraineeSearchRepository {
 			.join(trainee.member, member)
 			.where(
 				ptTrainerTrainee.trainer.id.eq(trainerId),
-				ptTrainerTrainee.deletedAt.isNull()
+				ptTrainerTrainee.deletedAt.isNull(),
+				member.deletedAt.isNull(),
+				trainee.deletedAt.isNull(),
+				trainer.deletedAt.isNull()
 			)
 			.fetch();
 	}

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietRepository.java
@@ -1,9 +1,12 @@
 package com.tnt.infrastructure.mysql.repository.trainee;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tnt.domain.trainee.Diet;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
 
+	Optional<Diet> findByIdAndTraineeIdAndDeletedAtIsNull(Long id, Long traineeId);
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietSearchRepository.java
@@ -18,7 +18,7 @@ public class DietSearchRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public List<Diet> findAllByTraineeIdForHome(Long traineeId, Integer year, Integer month) {
+	public List<Diet> findAllByTraineeIdForDaily(Long traineeId, Integer year, Integer month) {
 		LocalDate startOfMonth = LocalDate.of(year, month, 1);
 		LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
 

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietSearchRepository.java
@@ -1,0 +1,36 @@
+package com.tnt.infrastructure.mysql.repository.trainee;
+
+import static com.tnt.domain.trainee.QDiet.diet;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tnt.domain.trainee.Diet;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DietSearchRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<Diet> findAllByTraineeIdForHome(Long traineeId, Integer year, Integer month) {
+		LocalDate startOfMonth = LocalDate.of(year, month, 1);
+		LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+		return jpaQueryFactory
+			.selectFrom(diet)
+			.where(
+				diet.traineeId.eq(traineeId),
+				diet.date.goe(startOfMonth.atStartOfDay()),
+				diet.date.lt(endOfMonth.plusDays(1).atStartOfDay()),
+				diet.deletedAt.isNull()
+			)
+			.orderBy(diet.date.asc())
+			.fetch();
+	}
+}

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/TraineeRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/TraineeRepository.java
@@ -1,9 +1,12 @@
 package com.tnt.infrastructure.mysql.repository.trainee;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tnt.domain.trainee.Trainee;
 
 public interface TraineeRepository extends JpaRepository<Trainee, Integer> {
 
+	Optional<Trainee> findByMemberIdAndDeletedAtIsNull(Long memberId);
 }

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/TraineeSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/TraineeSearchRepository.java
@@ -24,6 +24,7 @@ public class TraineeSearchRepository {
 			.join(trainee.member, member).fetchJoin()
 			.where(
 				member.id.eq(memberId),
+				member.deletedAt.isNull(),
 				trainee.deletedAt.isNull()
 			)
 			.fetchOne());
@@ -35,6 +36,7 @@ public class TraineeSearchRepository {
 			.join(trainee.member, member).fetchJoin()
 			.where(
 				trainee.id.eq(id),
+				member.deletedAt.isNull(),
 				trainee.deletedAt.isNull()
 			)
 			.fetchOne());

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerSearchRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainer/TrainerSearchRepository.java
@@ -24,6 +24,7 @@ public class TrainerSearchRepository {
 			.join(trainer.member, member).fetchJoin()
 			.where(
 				member.id.eq(memberId),
+				member.deletedAt.isNull(),
 				trainer.deletedAt.isNull()
 			)
 			.fetchOne());
@@ -35,6 +36,7 @@ public class TrainerSearchRepository {
 			.join(trainer.member, member).fetchJoin()
 			.where(
 				trainer.invitationCode.eq(invitationCode),
+				member.deletedAt.isNull(),
 				trainer.deletedAt.isNull()
 			)
 			.fetchOne());

--- a/src/main/java/com/tnt/presentation/trainee/TraineeController.java
+++ b/src/main/java/com/tnt/presentation/trainee/TraineeController.java
@@ -8,6 +8,7 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import java.time.LocalDate;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +24,8 @@ import com.tnt.application.s3.S3Service;
 import com.tnt.dto.trainee.request.ConnectWithTrainerRequest;
 import com.tnt.dto.trainee.request.CreateDietRequest;
 import com.tnt.dto.trainee.response.ConnectWithTrainerResponse;
+import com.tnt.dto.trainee.response.CreateDietResponse;
+import com.tnt.dto.trainee.response.GetDietResponse;
 import com.tnt.dto.trainee.response.GetTraineeCalendarPtLessonCountResponse;
 import com.tnt.dto.trainer.ConnectWithTrainerDto;
 import com.tnt.gateway.config.AuthMember;
@@ -58,11 +61,20 @@ public class TraineeController {
 	@Operation(summary = "트레이니 식단 등록 API")
 	@ResponseStatus(CREATED)
 	@PostMapping(value = "/diets", consumes = MULTIPART_FORM_DATA_VALUE)
-	public void createDiet(@AuthMember Long memberId, @RequestPart("request") @Valid CreateDietRequest request,
+	public CreateDietResponse createDiet(@AuthMember Long memberId,
+		@RequestPart("request") @Valid CreateDietRequest request,
 		@RequestPart(value = "dietImage", required = false) MultipartFile dietImage) {
 		String dietImageUrl = s3Service.uploadImage(null, DIET_S3_IMAGE_PATH, dietImage);
 
-		ptService.createDiet(memberId, request, dietImageUrl);
+		return ptService.createDiet(memberId, request, dietImageUrl);
+	}
+
+	@Operation(summary = "특정 식단 조회 API")
+	@ResponseStatus(OK)
+	@GetMapping("/diets/{dietId}")
+	public GetDietResponse getDiet(@AuthMember Long memberId,
+		@Parameter(description = "식단 ID", example = "12345") @PathVariable("dietId") Long dietId) {
+		return ptService.getDiet(memberId, dietId);
 	}
 
 	@Operation(summary = "달력 PT 수업 있는 날 표시 데이터 조회 API")

--- a/src/main/java/com/tnt/presentation/trainee/TraineeController.java
+++ b/src/main/java/com/tnt/presentation/trainee/TraineeController.java
@@ -27,6 +27,7 @@ import com.tnt.dto.trainee.response.ConnectWithTrainerResponse;
 import com.tnt.dto.trainee.response.CreateDietResponse;
 import com.tnt.dto.trainee.response.GetDietResponse;
 import com.tnt.dto.trainee.response.GetTraineeCalendarPtLessonCountResponse;
+import com.tnt.dto.trainee.response.GetTraineeHomeRecordsResponse;
 import com.tnt.dto.trainer.ConnectWithTrainerDto;
 import com.tnt.gateway.config.AuthMember;
 
@@ -34,6 +35,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "트레이니", description = "트레이니 관련 API")
@@ -86,5 +89,14 @@ public class TraineeController {
 		@Parameter(description = "조회 종료 날짜", example = "2025-02-15")
 		@RequestParam("endDate") LocalDate endDate) {
 		return ptService.getTraineeCalendarPtLessonCount(memberId, startDate, endDate);
+	}
+
+	@Operation(summary = "홈 기록 리스트 조회 API")
+	@ResponseStatus(OK)
+	@GetMapping("/home")
+	public GetTraineeHomeRecordsResponse getHomeRecords(@AuthMember Long memberId,
+		@Parameter(description = "년도", example = "2025") @RequestParam("year") @Min(1900) @Max(2100) Integer year,
+		@Parameter(description = "월", example = "2") @RequestParam("month") @Min(1) @Max(12) Integer month) {
+		return ptService.getHomeRecords(memberId, year, month);
 	}
 }

--- a/src/main/java/com/tnt/presentation/trainee/TraineeController.java
+++ b/src/main/java/com/tnt/presentation/trainee/TraineeController.java
@@ -27,7 +27,7 @@ import com.tnt.dto.trainee.response.ConnectWithTrainerResponse;
 import com.tnt.dto.trainee.response.CreateDietResponse;
 import com.tnt.dto.trainee.response.GetDietResponse;
 import com.tnt.dto.trainee.response.GetTraineeCalendarPtLessonCountResponse;
-import com.tnt.dto.trainee.response.GetTraineeHomeRecordsResponse;
+import com.tnt.dto.trainee.response.GetTraineeDailyRecordsResponse;
 import com.tnt.dto.trainer.ConnectWithTrainerDto;
 import com.tnt.gateway.config.AuthMember;
 
@@ -93,10 +93,10 @@ public class TraineeController {
 
 	@Operation(summary = "홈 기록 리스트 조회 API")
 	@ResponseStatus(OK)
-	@GetMapping("/home")
-	public GetTraineeHomeRecordsResponse getHomeRecords(@AuthMember Long memberId,
+	@GetMapping("/calendar")
+	public GetTraineeDailyRecordsResponse getDailyRecords(@AuthMember Long memberId,
 		@Parameter(description = "년도", example = "2025") @RequestParam("year") @Min(1900) @Max(2100) Integer year,
 		@Parameter(description = "월", example = "2") @RequestParam("month") @Min(1) @Max(12) Integer month) {
-		return ptService.getHomeRecords(memberId, year, month);
+		return ptService.getDailyRecords(memberId, year, month);
 	}
 }

--- a/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
+++ b/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
@@ -29,7 +29,6 @@ import com.tnt.fixture.PtTrainerTraineeFixture;
 import com.tnt.fixture.TraineeFixture;
 import com.tnt.fixture.TrainerFixture;
 import com.tnt.gateway.service.SessionService;
-import com.tnt.infrastructure.mysql.repository.pt.PtTrainerTraineeRepository;
 
 @ExtendWith(MockitoExtension.class)
 class WithdrawServiceTest {
@@ -51,9 +50,6 @@ class WithdrawServiceTest {
 
 	@Mock
 	private PtService ptService;
-
-	@Mock
-	private PtTrainerTraineeRepository ptTrainerTraineeRepository;
 
 	@InjectMocks
 	private WithdrawService withdrawService;

--- a/src/test/java/com/tnt/application/pt/PtServiceTest.java
+++ b/src/test/java/com/tnt/application/pt/PtServiceTest.java
@@ -181,6 +181,7 @@ class PtServiceTest {
 		PtLesson ptLesson = PtLesson.builder()
 			.id(1L)
 			.ptTrainerTrainee(ptTrainerTrainee)
+			.session(1)
 			.lessonStart(LocalDateTime.of(date, LocalTime.of(10, 0)))
 			.lessonEnd(LocalDateTime.of(date, LocalTime.of(11, 0)))
 			.build();
@@ -285,18 +286,21 @@ class PtServiceTest {
 		List<PtLesson> ptLessons = List.of(PtLesson.builder()
 				.id(1L)
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(1)
 				.lessonStart(date)
 				.lessonEnd(date.plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.id(2L)
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(2)
 				.lessonStart(date.plusHours(4))
 				.lessonEnd(date.plusHours(5))
 				.build(),
 			PtLesson.builder()
 				.id(3L)
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(3)
 				.lessonStart(date.plusDays(1))
 				.lessonEnd(date.plusDays(1).plusHours(1))
 				.build());

--- a/src/test/java/com/tnt/domain/pt/PtLessonTest.java
+++ b/src/test/java/com/tnt/domain/pt/PtLessonTest.java
@@ -37,6 +37,7 @@ class PtLessonTest {
 		//when & then
 		assertThatThrownBy(() -> PtLesson.builder()
 			.ptTrainerTrainee(ptTrainerTrainee)
+			.session(1)
 			.lessonStart(LocalDateTime.of(2021, 1, 1, 10, 0))
 			.lessonEnd(LocalDateTime.of(2021, 1, 1, 11, 0))
 			.memo(failMemo)

--- a/src/test/java/com/tnt/fixture/DietFixture.java
+++ b/src/test/java/com/tnt/fixture/DietFixture.java
@@ -1,6 +1,8 @@
 package com.tnt.fixture;
 
+import static com.tnt.domain.trainee.DietType.BREAKFAST;
 import static com.tnt.domain.trainee.DietType.DINNER;
+import static com.tnt.domain.trainee.DietType.LUNCH;
 
 import java.time.LocalDateTime;
 
@@ -9,9 +11,51 @@ import com.tnt.domain.trainee.Diet;
 public final class DietFixture {
 
 	public static Diet getDiet1(Long traineeId) {
-		LocalDateTime date = LocalDateTime.parse("2025-02-11T15:38");
+		LocalDateTime date = LocalDateTime.parse("2025-02-01T11:38");
 		String dietImageUrl = "test1.jpg";
 		String memo = "배부름";
+
+		return Diet.builder()
+			.traineeId(traineeId)
+			.date(date)
+			.dietImageUrl(dietImageUrl)
+			.dietType(BREAKFAST)
+			.memo(memo)
+			.build();
+	}
+
+	public static Diet getDiet2(Long traineeId) {
+		LocalDateTime date = LocalDateTime.parse("2025-02-01T18:38");
+		String dietImageUrl = "test2.jpg";
+		String memo = "배고픔";
+
+		return Diet.builder()
+			.traineeId(traineeId)
+			.date(date)
+			.dietImageUrl(dietImageUrl)
+			.dietType(DINNER)
+			.memo(memo)
+			.build();
+	}
+
+	public static Diet getDiet3(Long traineeId) {
+		LocalDateTime date = LocalDateTime.parse("2025-02-02T12:38");
+		String dietImageUrl = "test3.jpg";
+		String memo = "모르겠음";
+
+		return Diet.builder()
+			.traineeId(traineeId)
+			.date(date)
+			.dietImageUrl(dietImageUrl)
+			.dietType(LUNCH)
+			.memo(memo)
+			.build();
+	}
+
+	public static Diet getDiet4(Long traineeId) {
+		LocalDateTime date = LocalDateTime.parse("2025-02-02T19:38");
+		String dietImageUrl = "test4.jpg";
+		String memo = "여전히";
 
 		return Diet.builder()
 			.traineeId(traineeId)

--- a/src/test/java/com/tnt/fixture/DietFixture.java
+++ b/src/test/java/com/tnt/fixture/DietFixture.java
@@ -1,0 +1,24 @@
+package com.tnt.fixture;
+
+import static com.tnt.domain.trainee.DietType.DINNER;
+
+import java.time.LocalDateTime;
+
+import com.tnt.domain.trainee.Diet;
+
+public final class DietFixture {
+
+	public static Diet getDiet1(Long traineeId) {
+		LocalDateTime date = LocalDateTime.parse("2025-02-11T15:38");
+		String dietImageUrl = "test1.jpg";
+		String memo = "배부름";
+
+		return Diet.builder()
+			.traineeId(traineeId)
+			.date(date)
+			.dietImageUrl(dietImageUrl)
+			.dietType(DINNER)
+			.memo(memo)
+			.build();
+	}
+}

--- a/src/test/java/com/tnt/fixture/PtLessonsFixture.java
+++ b/src/test/java/com/tnt/fixture/PtLessonsFixture.java
@@ -9,11 +9,44 @@ import com.tnt.domain.pt.PtTrainerTrainee;
 public class PtLessonsFixture {
 
 	public static List<PtLesson> getPtLessons1WithId(PtTrainerTrainee ptTrainerTrainee) {
+		LocalDateTime startDate1 = LocalDateTime.parse("2025-02-01T11:30");
+		LocalDateTime endDate1 = LocalDateTime.parse("2025-02-01T13:00");
+
+		LocalDateTime startDate2 = LocalDateTime.parse("2025-02-02T11:30");
+		LocalDateTime endDate2 = LocalDateTime.parse("2025-02-02T13:00");
+
 		return List.of(PtLesson.builder()
-			.id(1L)
-			.ptTrainerTrainee(ptTrainerTrainee)
-			.lessonStart(LocalDateTime.now())
-			.lessonEnd(LocalDateTime.now())
-			.build());
+				.id(1L)
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(startDate1)
+				.lessonEnd(endDate1)
+				.build(),
+			PtLesson.builder()
+				.id(2L)
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(startDate2)
+				.lessonEnd(endDate2)
+				.build()
+		);
+	}
+
+	public static List<PtLesson> getPtLessons1(PtTrainerTrainee ptTrainerTrainee) {
+		LocalDateTime startDate1 = LocalDateTime.parse("2025-02-01T11:30");
+		LocalDateTime endDate1 = LocalDateTime.parse("2025-02-01T13:00");
+
+		LocalDateTime startDate2 = LocalDateTime.parse("2025-02-02T11:30");
+		LocalDateTime endDate2 = LocalDateTime.parse("2025-02-02T13:00");
+
+		return List.of(PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(startDate1)
+				.lessonEnd(endDate1)
+				.build(),
+			PtLesson.builder()
+				.ptTrainerTrainee(ptTrainerTrainee)
+				.lessonStart(startDate2)
+				.lessonEnd(endDate2)
+				.build()
+		);
 	}
 }

--- a/src/test/java/com/tnt/fixture/PtLessonsFixture.java
+++ b/src/test/java/com/tnt/fixture/PtLessonsFixture.java
@@ -18,12 +18,14 @@ public class PtLessonsFixture {
 		return List.of(PtLesson.builder()
 				.id(1L)
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(1)
 				.lessonStart(startDate1)
 				.lessonEnd(endDate1)
 				.build(),
 			PtLesson.builder()
 				.id(2L)
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(2)
 				.lessonStart(startDate2)
 				.lessonEnd(endDate2)
 				.build()
@@ -39,11 +41,13 @@ public class PtLessonsFixture {
 
 		return List.of(PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(3)
 				.lessonStart(startDate1)
 				.lessonEnd(endDate1)
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(4)
 				.lessonStart(startDate2)
 				.lessonEnd(endDate2)
 				.build()

--- a/src/test/java/com/tnt/fixture/PtTrainerTraineeFixture.java
+++ b/src/test/java/com/tnt/fixture/PtTrainerTraineeFixture.java
@@ -11,7 +11,7 @@ public class PtTrainerTraineeFixture {
 	public static PtTrainerTrainee getPtTrainerTrainee1(Trainer trainer, Trainee trainee) {
 		LocalDate startDate = LocalDate.of(2025, 1, 1);
 		Integer totalPtCount = 10;
-		Integer finishedPtCount = 3;
+		Integer finishedPtCount = 9;
 
 		return PtTrainerTrainee.builder()
 			.trainer(trainer)

--- a/src/test/java/com/tnt/presentation/member/MemberControllerTest.java
+++ b/src/test/java/com/tnt/presentation/member/MemberControllerTest.java
@@ -315,7 +315,8 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 			.andExpect(jsonPath("$.trainee.birthday").value(traineeMember.getBirthday().toString()))
 			.andExpect(jsonPath("$.trainee.height").value(trainee.getHeight()))
 			.andExpect(jsonPath("$.trainee.weight").value(trainee.getWeight()))
-			.andExpect(jsonPath("$.trainee.cautionNote").value(trainee.getCautionNote()));
+			.andExpect(jsonPath("$.trainee.cautionNote").value(trainee.getCautionNote()))
+			.andDo(print());
 	}
 
 	@TestConfiguration

--- a/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
@@ -330,21 +330,25 @@ class TraineeControllerTest {
 
 		List<PtLesson> ptLessons = List.of(PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(1)
 				.lessonStart(date1)
 				.lessonEnd(date1.plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(2)
 				.lessonStart(date2)
 				.lessonEnd(date2.plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(3)
 				.lessonStart(date3)
 				.lessonEnd(date3.plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(4)
 				.lessonStart(date4)
 				.lessonEnd(date4.plusHours(1))
 				.build());
@@ -415,18 +419,17 @@ class TraineeControllerTest {
 		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
 		// when & then
-		mockMvc.perform(get("/trainees/home")
+		mockMvc.perform(get("/trainees/calendar")
 				.param("year", String.valueOf(2025))
 				.param("month", String.valueOf(2)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.dailyRecords").isArray())
 			.andExpect(jsonPath("$.dailyRecords[0].date").value(diet1.getDate().toLocalDate().format(dateFormatter)))
-			.andExpect(jsonPath("$.dailyRecords[0].ptInfos").isArray())
-			.andExpect(jsonPath("$.dailyRecords[0].ptInfos[0].trainerName").value(trainer.getMember().getName()))
-			.andExpect(jsonPath("$.dailyRecords[0].ptInfos[0].ptCount").value(10))
-			.andExpect(jsonPath("$.dailyRecords[0].ptInfos[0].lessonStart").value(
+			.andExpect(jsonPath("$.dailyRecords[0].ptInfo.trainerName").value(trainer.getMember().getName()))
+			.andExpect(jsonPath("$.dailyRecords[0].ptInfo.session").value(ptLesson.getFirst().getSession()))
+			.andExpect(jsonPath("$.dailyRecords[0].ptInfo.lessonStart").value(
 				ptLesson.getFirst().getLessonStart().format(dateTimeFormatter)))
-			.andExpect(jsonPath("$.dailyRecords[0].ptInfos[0].lessonEnd").value(
+			.andExpect(jsonPath("$.dailyRecords[0].ptInfo.lessonEnd").value(
 				ptLesson.getFirst().getLessonEnd().format(dateTimeFormatter)))
 			.andExpect(jsonPath("$.dailyRecords[0].diets").isArray())
 			.andExpect(jsonPath("$.dailyRecords[0].diets[0].dietId").value(diet1.getId()))

--- a/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainer/TrainerControllerTest.java
@@ -348,6 +348,7 @@ class TrainerControllerTest {
 			.ptTrainerTrainee(ptTrainerTrainee)
 			.lessonStart(LocalDateTime.of(2025, 1, 1, 10, 0))
 			.lessonEnd(LocalDateTime.of(2025, 1, 1, 11, 0))
+			.session(1)
 			.memo("THIS IS MEMO")
 			.build();
 
@@ -393,21 +394,25 @@ class TrainerControllerTest {
 
 		List<PtLesson> ptLessons = List.of(PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(1)
 				.lessonStart(date)
 				.lessonEnd(date.plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(2)
 				.lessonStart(date.plusHours(4))
 				.lessonEnd(date.plusHours(5))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(3)
 				.lessonStart(date.plusDays(1))
 				.lessonEnd(date.plusDays(1).plusHours(1))
 				.build(),
 			PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)
+				.session(4)
 				.lessonStart(date.plusDays(4).plusHours(4))
 				.lessonEnd(date.plusDays(4).plusHours(5))
 				.build());
@@ -615,6 +620,7 @@ class TrainerControllerTest {
 
 		ptLessonRepository.save(PtLesson.builder()
 			.ptTrainerTrainee(ptTrainerTrainee)
+			.session(1)
 			.lessonStart(createdStart)
 			.lessonEnd(createdEnd)
 			.build());
@@ -678,6 +684,7 @@ class TrainerControllerTest {
 
 		PtLesson ptLesson = PtLesson.builder()
 			.ptTrainerTrainee(ptTrainerTrainee)
+			.session(1)
 			.lessonStart(LocalDateTime.of(2025, 1, 1, 10, 0))
 			.lessonEnd(LocalDateTime.of(2025, 1, 1, 11, 0))
 			.memo("THIS IS MEMO")


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #59 

**✅ Tasks**

- 특정 식단 조회 API
  - dietId로 식단 주인만 조회 가능합니다.

- 홈 기록 리스트 조회 API
  - year랑 month로 트레이니의 한 달 치 기록들이 응답됩니다.
    - 날짜 별 PT 정보, 식단 목록이 들어갑니다.

- 트레이니 키, 몸무게 nullable 입니다.

- 마이페이지 회원 조회 API
  - 트레이니 경우, 응답에 트레이너 ID, 트레이너 초대 코드가 추가됐습니다.

**🙋🏻 More**

- 참고 내용