### PR TITLE
[TNT-253] fix: 회원 탈퇴 시 식단 데이터 삭제, 기타 수정

### DIFF
--- a/src/main/java/com/tnt/application/member/WithdrawService.java
+++ b/src/main/java/com/tnt/application/member/WithdrawService.java
@@ -66,7 +66,9 @@ public class WithdrawService {
 			}
 
 			trainer.softDelete();
-		} else if (member.getMemberType() == TRAINEE) {
+		}
+
+		if (member.getMemberType() == TRAINEE) {
 			Trainee trainee = traineeService.getTraineeWithMemberId(member.getId());
 			List<PtGoal> ptGoals = ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId());
 			List<Diet> diets = dietService.getAllDietsWithTraineeId(trainee.getId());

--- a/src/main/java/com/tnt/application/member/WithdrawService.java
+++ b/src/main/java/com/tnt/application/member/WithdrawService.java
@@ -1,19 +1,23 @@
 package com.tnt.application.member;
 
+import static com.tnt.domain.member.MemberType.TRAINEE;
+import static com.tnt.domain.member.MemberType.TRAINER;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tnt.application.pt.PtService;
+import com.tnt.application.trainee.DietService;
 import com.tnt.application.trainee.PtGoalService;
 import com.tnt.application.trainee.TraineeService;
 import com.tnt.application.trainer.TrainerService;
 import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.member.Member;
-import com.tnt.domain.member.MemberType;
 import com.tnt.domain.pt.PtLesson;
 import com.tnt.domain.pt.PtTrainerTrainee;
+import com.tnt.domain.trainee.Diet;
 import com.tnt.domain.trainee.PtGoal;
 import com.tnt.domain.trainee.Trainee;
 import com.tnt.domain.trainer.Trainer;
@@ -31,6 +35,7 @@ public class WithdrawService {
 	private final TrainerService trainerService;
 	private final TraineeService traineeService;
 	private final PtGoalService ptGoalService;
+	private final DietService dietService;
 	private final PtService ptService;
 
 	@Transactional
@@ -45,7 +50,7 @@ public class WithdrawService {
 	}
 
 	private void deleteMemberData(Member member) {
-		if (member.getMemberType() == MemberType.TRAINER) {
+		if (member.getMemberType() == TRAINER) {
 			Trainer trainer = trainerService.getTrainerWithMemberId(member.getId());
 
 			if (ptService.isPtTrainerTraineeExistWithTrainerId(trainer.getId())) {
@@ -65,9 +70,10 @@ public class WithdrawService {
 			}
 
 			trainer.softDelete();
-		} else if (member.getMemberType() == MemberType.TRAINEE) {
+		} else if (member.getMemberType() == TRAINEE) {
 			Trainee trainee = traineeService.getTraineeWithMemberId(member.getId());
 			List<PtGoal> ptGoals = ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId());
+			List<Diet> diets = dietService.getAllDietsWithTraineeId(trainee.getId());
 
 			if (ptService.isPtTrainerTraineeExistWithTraineeId(trainee.getId())) {
 				try {
@@ -82,6 +88,8 @@ public class WithdrawService {
 			}
 
 			ptGoals.forEach(PtGoal::softDelete);
+
+			diets.forEach(Diet::softDelete);
 
 			trainee.softDelete();
 		}

--- a/src/main/java/com/tnt/application/member/WithdrawService.java
+++ b/src/main/java/com/tnt/application/member/WithdrawService.java
@@ -54,19 +54,15 @@ public class WithdrawService {
 			Trainer trainer = trainerService.getTrainerWithMemberId(member.getId());
 
 			if (ptService.isPtTrainerTraineeExistWithTrainerId(trainer.getId())) {
-				try {
-					List<PtTrainerTrainee> ptTrainerTrainee = ptService.getAllPtTrainerTraineeWithTrainerId(
-						trainer.getId());
+				List<PtTrainerTrainee> ptTrainerTrainee = ptService.getAllPtTrainerTraineeWithTrainerId(
+					trainer.getId());
 
-					List<PtLesson> ptLessons = ptTrainerTrainee.stream().map(ptService::getPtLessonWithPtTrainerTrainee)
-						.flatMap(List::stream)
-						.toList();
+				List<PtLesson> ptLessons = ptTrainerTrainee.stream().map(ptService::getPtLessonWithPtTrainerTrainee)
+					.flatMap(List::stream)
+					.toList();
 
-					ptLessons.forEach(PtLesson::softDelete);
-					ptTrainerTrainee.forEach(PtTrainerTrainee::softDelete);
-				} catch (NotFoundException e) {
-					// Do nothing
-				}
+				ptLessons.forEach(PtLesson::softDelete);
+				ptTrainerTrainee.forEach(PtTrainerTrainee::softDelete);
 			}
 
 			trainer.softDelete();

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -277,8 +277,7 @@ public class PtService {
 			date).orElse(new TraineeProjection.PtInfoDto(null, null, null, null, null));
 
 		// PT 정보 Mapping to PtInfo
-		GetTraineeDailyRecordsResponse.PtInfo ptInfo = new GetTraineeDailyRecordsResponse.PtInfo(ptResult.trainerName(),
-			ptResult.trainerProfileImage(), ptResult.session(), ptResult.lessonStart(), ptResult.lessonEnd());
+		GetTraineeDailyRecordsResponse.PtInfo ptInfo = toPtInfo(ptResult);
 
 		// 식단 정보 조회
 		List<Diet> diets = dietService.getDietsWithTraineeIdForDaily(trainee.getId(), date);
@@ -376,5 +375,19 @@ public class PtService {
 		}
 
 		return ptTrainerTrainee.getFinishedPtCount() + 1 + temp;
+	}
+
+	private GetTraineeDailyRecordsResponse.PtInfo toPtInfo(TraineeProjection.PtInfoDto dto) {
+		if (isAllFieldsNull(dto)) {
+			return null;
+		}
+
+		return new GetTraineeDailyRecordsResponse.PtInfo(dto.trainerName(), dto.trainerProfileImage(), dto.session(),
+			dto.lessonStart(), dto.lessonEnd());
+	}
+
+	private boolean isAllFieldsNull(TraineeProjection.PtInfoDto dto) {
+		return dto.trainerName() == null && dto.trainerProfileImage() == null && dto.session() == null
+			&& dto.lessonStart() == null && dto.lessonEnd() == null;
 	}
 }

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -378,16 +378,11 @@ public class PtService {
 	}
 
 	private GetTraineeDailyRecordsResponse.PtInfo toPtInfo(TraineeProjection.PtInfoDto dto) {
-		if (isAllFieldsNull(dto)) {
+		if (dto.session() == null) {
 			return null;
 		}
 
 		return new GetTraineeDailyRecordsResponse.PtInfo(dto.trainerName(), dto.trainerProfileImage(), dto.session(),
 			dto.lessonStart(), dto.lessonEnd());
-	}
-
-	private boolean isAllFieldsNull(TraineeProjection.PtInfoDto dto) {
-		return dto.trainerName() == null && dto.trainerProfileImage() == null && dto.session() == null
-			&& dto.lessonStart() == null && dto.lessonEnd() == null;
 	}
 }

--- a/src/main/java/com/tnt/application/pt/PtService.java
+++ b/src/main/java/com/tnt/application/pt/PtService.java
@@ -277,7 +277,11 @@ public class PtService {
 			date).orElse(new TraineeProjection.PtInfoDto(null, null, null, null, null));
 
 		// PT 정보 Mapping to PtInfo
-		GetTraineeDailyRecordsResponse.PtInfo ptInfo = toPtInfo(ptResult);
+		GetTraineeDailyRecordsResponse.PtInfo ptInfo =
+			(ptResult.trainerName() == null && ptResult.trainerProfileImage() == null && ptResult.session() == null
+				&& ptResult.lessonStart() == null && ptResult.lessonEnd() == null) ? null :
+				new GetTraineeDailyRecordsResponse.PtInfo(ptResult.trainerName(), ptResult.trainerProfileImage(),
+					ptResult.session(), ptResult.lessonStart(), ptResult.lessonEnd());
 
 		// 식단 정보 조회
 		List<Diet> diets = dietService.getDietsWithTraineeIdForDaily(trainee.getId(), date);
@@ -375,14 +379,5 @@ public class PtService {
 		}
 
 		return ptTrainerTrainee.getFinishedPtCount() + 1 + temp;
-	}
-
-	private GetTraineeDailyRecordsResponse.PtInfo toPtInfo(TraineeProjection.PtInfoDto dto) {
-		if (dto.session() == null) {
-			return null;
-		}
-
-		return new GetTraineeDailyRecordsResponse.PtInfo(dto.trainerName(), dto.trainerProfileImage(), dto.session(),
-			dto.lessonStart(), dto.lessonEnd());
 	}
 }

--- a/src/main/java/com/tnt/application/trainee/DietService.java
+++ b/src/main/java/com/tnt/application/trainee/DietService.java
@@ -32,6 +32,10 @@ public class DietService {
 			.orElseThrow(() -> new NotFoundException(DIET_NOT_FOUND));
 	}
 
+	public List<Diet> getAllDietsWithTraineeId(Long traineeId) {
+		return dietRepository.findAllByTraineeIdAndDeletedAtIsNull(traineeId);
+	}
+
 	public List<Diet> getDietsWithTraineeIdForDaily(Long traineeId, LocalDate date) {
 		return dietSearchRepository.findAllByTraineeIdForDaily(traineeId, date);
 	}

--- a/src/main/java/com/tnt/domain/trainee/Diet.java
+++ b/src/main/java/com/tnt/domain/trainee/Diet.java
@@ -80,4 +80,8 @@ public class Diet extends BaseTimeEntity {
 
 		return memo;
 	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/tnt/dto/trainer/response/ConnectWithTraineeResponse.java
+++ b/src/main/java/com/tnt/dto/trainer/response/ConnectWithTraineeResponse.java
@@ -31,10 +31,10 @@ public record ConnectWithTraineeResponse(
 		@Schema(description = "트레이니 나이", example = "25", nullable = true)
 		Integer traineeAge,
 
-		@Schema(description = "트레이니 키", example = "178.6cm", nullable = false)
+		@Schema(description = "트레이니 키", example = "178.6cm", nullable = true)
 		Double height,
 
-		@Schema(description = "트레이니 몸무게", example = "70.2kg", nullable = false)
+		@Schema(description = "트레이니 몸무게", example = "70.2kg", nullable = true)
 		Double weight,
 
 		@Schema(description = "PT 목표", example = "체중 감량, 근력 향상, 건강 관리", nullable = false)

--- a/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietRepository.java
+++ b/src/main/java/com/tnt/infrastructure/mysql/repository/trainee/DietRepository.java
@@ -1,5 +1,6 @@
 package com.tnt.infrastructure.mysql.repository.trainee;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import com.tnt.domain.trainee.Diet;
 public interface DietRepository extends JpaRepository<Diet, Long> {
 
 	Optional<Diet> findByIdAndTraineeIdAndDeletedAtIsNull(Long id, Long traineeId);
+
+	List<Diet> findAllByTraineeIdAndDeletedAtIsNull(Long traineeId);
 }

--- a/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
+++ b/src/test/java/com/tnt/application/member/WithdrawServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.tnt.application.pt.PtService;
+import com.tnt.application.trainee.DietService;
 import com.tnt.application.trainee.PtGoalService;
 import com.tnt.application.trainee.TraineeService;
 import com.tnt.application.trainer.TrainerService;
@@ -20,9 +21,11 @@ import com.tnt.common.error.exception.NotFoundException;
 import com.tnt.domain.member.Member;
 import com.tnt.domain.pt.PtLesson;
 import com.tnt.domain.pt.PtTrainerTrainee;
+import com.tnt.domain.trainee.Diet;
 import com.tnt.domain.trainee.PtGoal;
 import com.tnt.domain.trainee.Trainee;
 import com.tnt.domain.trainer.Trainer;
+import com.tnt.fixture.DietFixture;
 import com.tnt.fixture.MemberFixture;
 import com.tnt.fixture.PtLessonsFixture;
 import com.tnt.fixture.PtTrainerTraineeFixture;
@@ -47,6 +50,9 @@ class WithdrawServiceTest {
 
 	@Mock
 	private PtGoalService ptGoalService;
+
+	@Mock
+	private DietService dietService;
 
 	@Mock
 	private PtService ptService;
@@ -79,10 +85,12 @@ class WithdrawServiceTest {
 		Trainee trainee = TraineeFixture.getTrainee1WithId(1L, traineeMember);
 
 		List<PtGoal> ptGoals = List.of(PtGoal.builder().id(1L).traineeId(trainee.getId()).content("test").build());
+		List<Diet> diets = List.of(DietFixture.getDiet1(trainee.getId()), DietFixture.getDiet2(trainee.getId()));
 
 		given(memberService.getMemberWithMemberId(traineeMember.getId())).willReturn(traineeMember);
 		given(traineeService.getTraineeWithMemberId(traineeMember.getId())).willReturn(trainee);
 		given(ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId())).willReturn(ptGoals);
+		given(dietService.getAllDietsWithTraineeId(trainee.getId())).willReturn(diets);
 
 		// when
 		withdrawService.withdraw(traineeMember.getId());
@@ -131,6 +139,7 @@ class WithdrawServiceTest {
 		PtTrainerTrainee ptTrainerTrainee = PtTrainerTraineeFixture.getPtTrainerTrainee1(trainer, trainee);
 
 		List<PtGoal> ptGoals = List.of(PtGoal.builder().id(1L).traineeId(trainee.getId()).content("test").build());
+		List<Diet> diets = List.of(DietFixture.getDiet1(trainee.getId()), DietFixture.getDiet2(trainee.getId()));
 
 		List<PtLesson> ptLessons = PtLessonsFixture.getPtLessons1WithId(ptTrainerTrainee);
 
@@ -138,6 +147,7 @@ class WithdrawServiceTest {
 		given(traineeService.getTraineeWithMemberId(traineeMember.getId())).willReturn(trainee);
 		given(ptService.isPtTrainerTraineeExistWithTraineeId(trainee.getId())).willReturn(true);
 		given(ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId())).willReturn(ptGoals);
+		given(dietService.getAllDietsWithTraineeId(trainee.getId())).willReturn(diets);
 		given(ptService.getPtTrainerTraineeWithTraineeId(trainee.getId())).willReturn(ptTrainerTrainee);
 		given(ptService.getPtLessonWithPtTrainerTrainee(ptTrainerTrainee)).willReturn(ptLessons);
 
@@ -176,11 +186,13 @@ class WithdrawServiceTest {
 		Trainee trainee = TraineeFixture.getTrainee1WithId(1L, traineeMember);
 
 		List<PtGoal> ptGoals = List.of(PtGoal.builder().id(1L).traineeId(trainee.getId()).content("test").build());
+		List<Diet> diets = List.of(DietFixture.getDiet1(trainee.getId()), DietFixture.getDiet2(trainee.getId()));
 
 		given(memberService.getMemberWithMemberId(traineeMember.getId())).willReturn(traineeMember);
 		given(traineeService.getTraineeWithMemberId(traineeMember.getId())).willReturn(trainee);
 		given(ptService.isPtTrainerTraineeExistWithTraineeId(trainee.getId())).willReturn(true);
 		given(ptGoalService.getAllPtGoalsWithTraineeId(trainee.getId())).willReturn(ptGoals);
+		given(dietService.getAllDietsWithTraineeId(trainee.getId())).willReturn(diets);
 		given(ptService.getPtTrainerTraineeWithTraineeId(trainee.getId())).willThrow(NotFoundException.class);
 
 		// when

--- a/src/test/java/com/tnt/fixture/PtLessonsFixture.java
+++ b/src/test/java/com/tnt/fixture/PtLessonsFixture.java
@@ -36,8 +36,8 @@ public class PtLessonsFixture {
 		LocalDateTime startDate1 = LocalDateTime.parse("2025-02-01T11:30");
 		LocalDateTime endDate1 = LocalDateTime.parse("2025-02-01T13:00");
 
-		LocalDateTime startDate2 = LocalDateTime.parse("2025-02-02T11:30");
-		LocalDateTime endDate2 = LocalDateTime.parse("2025-02-02T13:00");
+		LocalDateTime startDate2 = LocalDateTime.parse("2025-02-05T11:30");
+		LocalDateTime endDate2 = LocalDateTime.parse("2025-02-05T13:00");
 
 		return List.of(PtLesson.builder()
 				.ptTrainerTrainee(ptTrainerTrainee)

--- a/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
@@ -428,6 +428,7 @@ class TraineeControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.date").value(targetDate.format(dateFormatter)))
 			.andExpect(jsonPath("$.ptInfo.trainerName").value(trainer.getMember().getName()))
+			.andExpect(jsonPath("$.ptInfo.trainerProfileImage").value(trainer.getMember().getProfileImageUrl()))
 			.andExpect(jsonPath("$.ptInfo.session").value(ptLesson.getSession()))
 			.andExpect(jsonPath("$.ptInfo.lessonStart").value(ptLesson.getLessonStart().format(dateTimeFormatter)))
 			.andExpect(jsonPath("$.ptInfo.lessonEnd").value(ptLesson.getLessonEnd().format(dateTimeFormatter)))

--- a/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
+++ b/src/test/java/com/tnt/presentation/trainee/TraineeControllerTest.java
@@ -444,4 +444,67 @@ class TraineeControllerTest {
 			.andExpect(jsonPath("$.diets[1].dietType").value(diet2.getDietType().toString()))
 			.andDo(print());
 	}
+
+	@Test
+	@DisplayName("통합 테스트 - 트레이니 PT 수업 없는 날 특정 날짜 기록 조회 성공")
+	void get_calendar_daily_records_without_pt_info_success() throws Exception {
+		// given
+		Member trainerMember = MemberFixture.getTrainerMember1();
+		Member traineeMember = MemberFixture.getTraineeMember2();
+
+		trainerMember = memberRepository.save(trainerMember);
+		traineeMember = memberRepository.save(traineeMember);
+
+		CustomUserDetails traineeUserDetails = new CustomUserDetails(traineeMember.getId(),
+			traineeMember.getId().toString(),
+			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(traineeUserDetails, null,
+			authoritiesMapper.mapAuthorities(traineeUserDetails.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Trainer trainer = TrainerFixture.getTrainer2(trainerMember);
+		Trainee trainee = TraineeFixture.getTrainee1(traineeMember);
+
+		trainerRepository.save(trainer);
+		traineeRepository.save(trainee);
+
+		PtTrainerTrainee ptTrainerTrainee = PtTrainerTraineeFixture.getPtTrainerTrainee1(trainer, trainee);
+
+		ptTrainerTraineeRepository.save(ptTrainerTrainee);
+
+		PtLesson ptLesson = PtLessonsFixture.getPtLessons1(ptTrainerTrainee).getFirst();
+
+		ptLessonRepository.save(ptLesson);
+
+		Diet diet3 = DietFixture.getDiet3(trainee.getId());
+		Diet diet4 = DietFixture.getDiet4(trainee.getId());
+
+		List<Diet> diets = List.of(diet3, diet4);
+
+		dietRepository.saveAll(diets);
+
+		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+		LocalDate targetDate = diet3.getDate().toLocalDate();
+
+		// when & then
+		mockMvc.perform(get("/trainees/calendar/{date}", targetDate))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.date").value(targetDate.format(dateFormatter)))
+			.andExpect(jsonPath("$.ptInfo").doesNotExist())
+			.andExpect(jsonPath("$.diets").isArray())
+			.andExpect(jsonPath("$.diets[0].dietId").value(diet3.getId()))
+			.andExpect(jsonPath("$.diets[0].date").value(diet3.getDate().format(dateTimeFormatter)))
+			.andExpect(jsonPath("$.diets[0].dietImageUrl").value(diet3.getDietImageUrl()))
+			.andExpect(jsonPath("$.diets[0].memo").value(diet3.getMemo()))
+			.andExpect(jsonPath("$.diets[0].dietType").value(diet3.getDietType().toString()))
+			.andExpect(jsonPath("$.diets[1].dietId").value(diet4.getId()))
+			.andExpect(jsonPath("$.diets[1].date").value(diet4.getDate().format(dateTimeFormatter)))
+			.andExpect(jsonPath("$.diets[1].dietImageUrl").value(diet4.getDietImageUrl()))
+			.andExpect(jsonPath("$.diets[1].memo").value(diet4.getMemo()))
+			.andExpect(jsonPath("$.diets[1].dietType").value(diet4.getDietType().toString()))
+			.andDo(print());
+	}
 }


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[APP2-77] feat: 회원 인증 Filter 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #63 

**✅ Tasks**

- [회원] 회원 탈퇴 API
  - 트레이니 회원 탈퇴 시 식단 데이터도 ``soft delete`` 하도록 수정했습니다.

- [트레이니] 홈 특정 날짜 기록 조회 API
  - PT 수업 없는 날은 응답에서 ``{"ptInfo": null}`` 로 나오도록 수정했습니다.

- swagger에서 키, 몸무게 ``nullable = true`` 로 수정했습니다.

**🙋🏻 More**

- 참고 내용
